### PR TITLE
Add OracleDB support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "sqltools",
-    "version": "0.12.1",
+    "version": "0.13.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -108,6 +108,15 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.13.tgz",
             "integrity": "sha512-Y3EAG7VA7NVNbZek/fjJtILnmTk/ZfpJuWZGDBqDZ1dVIxgJJJ82fXPW7pKnqyV9CD/9bcPOCi7eErUqGMHOrA==",
             "dev": true
+        },
+        "@types/oracledb": {
+            "version": "1.11.34",
+            "resolved": "https://registry.npmjs.org/@types/oracledb/-/oracledb-1.11.34.tgz",
+            "integrity": "sha512-7cgZaKEfYcPPTScxxCoYoLxmmhM/PBobGBfxE3RGzRJl8YKhkyGKyExFu8fTOpF2cPgdfh83NGKBVX7prWzb+Q==",
+            "dev": true,
+            "requires": {
+                "@types/node": "8.0.13"
+            }
         },
         "@types/react": {
             "version": "16.0.34",
@@ -2160,6 +2169,12 @@
                 "restore-cursor": "2.0.0"
             }
         },
+        "cli-spinners": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.3.1.tgz",
+            "integrity": "sha512-1QL4544moEsDVH9T/l6Cemov/37iv1RtoKf7NJ04A60+4MREXNfx/QvavbH6QoGdsD4N4Mwy49cmaINR/o2mdg==",
+            "dev": true
+        },
         "cli-width": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
@@ -2788,6 +2803,12 @@
                 "repeating": "2.0.1"
             }
         },
+        "detect-libc": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+            "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+            "dev": true
+        },
         "detect-newline": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
@@ -2897,6 +2918,24 @@
             "optional": true,
             "requires": {
                 "jsbn": "0.1.1"
+            }
+        },
+        "electron-rebuild": {
+            "version": "1.7.3",
+            "resolved": "https://registry.npmjs.org/electron-rebuild/-/electron-rebuild-1.7.3.tgz",
+            "integrity": "sha1-JK4GrZ3WHLfk1oiWH0kRjEChEOs=",
+            "dev": true,
+            "requires": {
+                "colors": "1.1.2",
+                "debug": "2.6.8",
+                "detect-libc": "1.0.3",
+                "fs-extra": "3.0.1",
+                "node-abi": "2.4.1",
+                "node-gyp": "3.6.2",
+                "ora": "1.4.0",
+                "rimraf": "2.6.1",
+                "spawn-rx": "2.0.12",
+                "yargs": "7.1.0"
             }
         },
         "elliptic": {
@@ -7325,6 +7364,52 @@
                 "lodash.escape": "3.2.0"
             }
         },
+        "log-symbols": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+            "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+            "dev": true,
+            "requires": {
+                "chalk": "2.4.1"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.4.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "3.0.0"
+                    }
+                }
+            }
+        },
         "long": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
@@ -7820,8 +7905,7 @@
         "nan": {
             "version": "2.8.0",
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-            "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
-            "dev": true
+            "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
         },
         "nanomatch": {
             "version": "1.2.9",
@@ -7899,6 +7983,23 @@
             "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
             "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
             "dev": true
+        },
+        "node-abi": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.4.1.tgz",
+            "integrity": "sha512-pUlswqpHQ7zGPI9lGjZ4XDNIEUDbHxsltfIRb7dTnYdhgHWHOcB0MLZKLoCz6UMcGzSPG5wGl1HODZVQAUsH6w==",
+            "dev": true,
+            "requires": {
+                "semver": "5.5.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+                    "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+                    "dev": true
+                }
+            }
         },
         "node-fetch": {
             "version": "1.7.3",
@@ -8407,6 +8508,61 @@
                     "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
                     "dev": true
                 }
+            }
+        },
+        "ora": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/ora/-/ora-1.4.0.tgz",
+            "integrity": "sha512-iMK1DOQxzzh2MBlVsU42G80mnrvUhqsMh74phHtDlrcTZPK0pH6o7l7DRshK+0YsxDyEuaOkziVdvM3T0QTzpw==",
+            "dev": true,
+            "requires": {
+                "chalk": "2.4.1",
+                "cli-cursor": "2.1.0",
+                "cli-spinners": "1.3.1",
+                "log-symbols": "2.2.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.4.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "3.0.0"
+                    }
+                }
+            }
+        },
+        "oracledb": {
+            "version": "github:oracle/node-oracledb#6c715d6b372efccfde4b01b90153586222724230",
+            "requires": {
+                "nan": "2.8.0"
             }
         },
         "orchestrator": {
@@ -9536,6 +9692,15 @@
                 "rx-lite": "4.0.8"
             }
         },
+        "rxjs": {
+            "version": "5.5.10",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.10.tgz",
+            "integrity": "sha512-SRjimIDUHJkon+2hFo7xnvNC4ZEHGzCRwh9P7nzX3zPkCGFEg/tuElrNR7L/rZMagnK2JeH2jQwPRpmyXyLB6A==",
+            "dev": true,
+            "requires": {
+                "symbol-observable": "1.0.1"
+            }
+        },
         "safe-buffer": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
@@ -9969,6 +10134,17 @@
             "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
             "dev": true
         },
+        "spawn-rx": {
+            "version": "2.0.12",
+            "resolved": "https://registry.npmjs.org/spawn-rx/-/spawn-rx-2.0.12.tgz",
+            "integrity": "sha512-gOPXiQQFQ9lTOLuys0iMn3jfxxv9c7zzwhbYLOEbQGvEShHVJ5sSR1oD3Daj88os7jKArDYT7rbOKdvNhe7iEg==",
+            "dev": true,
+            "requires": {
+                "debug": "2.6.8",
+                "lodash.assign": "4.2.0",
+                "rxjs": "5.5.10"
+            }
+        },
         "spdx-correct": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
@@ -10315,6 +10491,12 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
             "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+            "dev": true
+        },
+        "symbol-observable": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+            "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
             "dev": true
         },
         "symbol-tree": {

--- a/package.json
+++ b/package.json
@@ -366,7 +366,8 @@
                                 "enum": [
                                     "MSSQL",
                                     "MySQL",
-                                    "PostgreSQL"
+                                    "PostgreSQL",
+                                    "OracleDB"
                                 ],
                                 "description": "Connection Dialect",
                                 "required": false
@@ -487,6 +488,7 @@
     "devDependencies": {
         "@types/jest": "^20.0.0",
         "@types/node": "^8.0.13",
+        "@types/oracledb": "^1.11.34",
         "@types/react": "^16.0.34",
         "@types/universal-analytics": "^0.4.2",
         "babel-preset-es2015": "^6.24.1",
@@ -496,6 +498,7 @@
         "browserify-incremental": "^3.1.1",
         "eslint": "^4.19.1",
         "eslint-plugin-react": "^7.5.1",
+        "electron-rebuild": "^1.7.3",
         "gulp": "^3.9.1",
         "gulp-sass": "^3.1.0",
         "gulp-sourcemaps": "^2.6.0",
@@ -520,6 +523,7 @@
         "get-port": "^3.2.0",
         "mysql2": "^1.5.1",
         "opn": "^5.1.0",
+        "oracledb": "github:oracle/node-oracledb#v2.1.2",
         "pg": "^7.4.0",
         "sql-formatter": "^2.1.0",
         "tedious": "^2.3.1",

--- a/src/api/dialect/index.ts
+++ b/src/api/dialect/index.ts
@@ -1,11 +1,13 @@
 import MSSQL from './mssql';
 import MySQL from './mysql';
+import OracleDB from './oracledb';
 import PostgreSQL from './pgsql';
 
 const dialects = {
   MSSQL,
   MySQL,
   PostgreSQL,
+  OracleDB,
 };
 
 export default dialects;

--- a/src/api/dialect/oracledb.ts
+++ b/src/api/dialect/oracledb.ts
@@ -1,0 +1,161 @@
+import * as oracledb from 'oracledb';
+
+import {
+  ConnectionCredentials,
+  ConnectionDialect,
+  DatabaseInterface,
+  DialectQueries,
+} from './../interface';
+import Utils from './../utils';
+import { runInThisContext } from 'vm';
+import { IConnection } from 'vscode-languageserver/lib/main';
+
+export default class OracleDB implements ConnectionDialect {
+  public connection: oracledb.IConnection;
+  private pool: oracledb.IConnectionPool;
+  private queries: DialectQueries = {
+    describeTable: `select * from all_tab_columns
+      where table_name = ':table'
+      and owner = ':schema'`,
+    fetchColumns: `select
+    c.table_name as tablename,
+    c.column_name as columnname,
+    c.data_type as type,
+    c.data_length as "size",
+    user as tablecatalog,
+    c.owner as tableschema,
+    c.owner as dbname,
+    c.data_default as defaultvalue,
+    c.nullable as isnullable
+    from all_tab_columns c
+    join (
+    select table_name, owner from all_tables
+    union all
+    select view_name as table_name, owner from all_views
+    ) v on (c.table_name = v.table_name and c.owner = v.owner)
+    where c.owner not like '%SYS%'`,
+    fetchRecords: 'select * from :table where rownum <= :limit',
+    fetchTables: `select
+    table_name as tableName,
+    owner AS tableSchema,
+    user AS tableCatalog,
+    isview AS isView,
+    owner AS dbName,
+    num_rows AS numberOfColumns
+    from (
+    select t.table_name, t.owner, user, 0 as isview, count(1) as num_rows
+    from all_tables t
+    join all_tab_columns c on c.table_name = t.table_name and c.owner = t.owner
+    group by t.owner, t.table_name, user
+    union all
+    select v.view_name as table_name, v.owner, user, 1 as isview, count(1) as num_rows
+    from all_views v
+    join all_tab_columns c on c.table_name = v.view_name and c.owner = v.owner
+    group by v.owner, v.view_name, user
+    )
+    where owner not like '%SYS%'`,
+  } as DialectQueries;
+  constructor(public credentials: ConnectionCredentials) {
+
+  }
+
+  public async open() {
+    if (this.connection) {
+      return this.connection;
+    }
+    // oracleConnectString = host_name + ":" + port + "/" + service_name;
+    const connectString = (this.credentials.server && this.credentials.port) ?
+      `${this.credentials.server}:${this.credentials.port}/${this.credentials.database}` :
+      this.credentials.database;
+
+    const options = {
+      connectString,
+      password: this.credentials.password,
+      user: this.credentials.username,
+    };
+    this.pool = await oracledb.createPool(options);
+    this.connection = await this.pool.getConnection();
+    return this.connection;
+  }
+
+  public async close() {
+    if (!this.connection) return Promise.resolve();
+
+    const closed = await this.connection.close();
+    await this.pool.close();
+    this.connection = null;
+    return closed;
+  }
+
+  public async query(query: string): Promise<DatabaseInterface.QueryResults[]> {
+    return this.open()
+      .then(async (conn) => await conn.execute(query, [], {outFormat: oracledb.OBJECT}))
+      .then((results: any[] | any) => {
+        const queries = query.split(/\s*;\s*(?=([^']*'[^']*')*[^']*$)/g);
+        const messages = [];
+        results = [ results ];
+
+        return results.map((r, i) => {
+          if (r.rowsAffected) {
+            messages.push(`${r.rowsAffected} rows were affected.`);
+          }
+          return {
+            cols: (r.rows && r.rows.length) > 0 ? Object.keys(r.rows[0]) : [],
+            messages,
+            query: queries[i],
+            results: r.rows,
+          };
+        });
+      });
+  }
+
+  public getTables(): Promise<DatabaseInterface.Table[]> {
+    return this.query(this.queries.fetchTables)
+      .then(([queryRes]) => {
+        return queryRes.results
+          .reduce((prev, curr) => prev.concat(curr), [])
+          .map((obj) => {
+            return {
+              name: `${obj.TABLESCHEMA}.${obj.TABLENAME}`,
+              isView: !!obj.ISVIEW,
+              numberOfColumns: parseInt(obj.NUMBEROFCOLUMNS, 10),
+              tableCatalog: obj.TABLECATALOG,
+              tableDatabase: obj.DBNAME,
+              tableSchema: obj.TABLESCHEMA,
+            } as DatabaseInterface.Table;
+          })
+          .sort();
+      });
+  }
+
+  public getColumns(): Promise<DatabaseInterface.TableColumn[]> {
+    return this.query(this.queries.fetchColumns)
+      .then(([queryRes]) => {
+        return queryRes.results
+          .reduce((prev, curr) => prev.concat(curr), [])
+          .map((obj) => {
+            return {
+              columnName: obj.COLUMNNAME,
+              defaultValue: obj.DEFAULTVALUE,
+              isNullable: !!obj.ISNULLABLE ? obj.ISNULLABLE.toString() === 'yes' : null,
+              size: obj.size !== null ? parseInt(obj.SIZE, 10) : null,
+              tableCatalog: obj.TABLECATALOG,
+              tableDatabase: obj.DBNAME,
+              tableName: `${obj.TABLESCHEMA}.${obj.TABLENAME}`,
+              tableSchema: obj.TABLESCHEMA,
+              type: obj.TYPE,
+            } as DatabaseInterface.TableColumn;
+          })
+          .sort();
+      });
+  }
+
+  public describeTable(table: string) {
+    const tableSplit = table.split('.');
+    return this.query(Utils.replacer(this.queries.describeTable, { schema: tableSplit[0], table: tableSplit[1] }));
+  }
+
+  public showRecords(table: string, limit: number = 10) {
+    return this.query(Utils.replacer(this.queries.fetchRecords, { limit, table }));
+  }
+}

--- a/src/languageserver/http-server/views/js/components/setup.jsx
+++ b/src/languageserver/http-server/views/js/components/setup.jsx
@@ -12,7 +12,8 @@ import Loading from './loading.jsx'
 const dialectDefaultPorts = {
   'MySQL': 3306,
   'MSSQL': 1433,
-  'PostgreSQL': 5432
+  'PostgreSQL': 5432,
+  'OracleDB': 1521
 }
 
 class Syntax extends React.Component {


### PR DESCRIPTION
Hey!

The OracleDB requires a bit of hassle around installation as it has to be rebuild against the version of Electron that VSCode depends on.

Thats the hardest part, the rest works like a charm. :)

```bash
## Install Windows-Build-Tools:
> npm --add-python-to-path install --global --production windows-build-tools
## Compile Oracle drivers against Electron version in latest VSCode (1.23.1):
## Architecture of Oracle drivers (instanclient) and VSCode must match (--arch=x64)
> \node_modules\.bin\electron-rebuild.cmd --version=1.7.0
```

