### PR TITLE
Add option to disable or enable table columns collapse on first load

### DIFF
--- a/package.json
+++ b/package.json
@@ -407,6 +407,11 @@
                     "type": "number",
                     "description": "Global show records limit",
                     "default": 10
+                },
+                "sqltools.tableTreeItemsExpanded": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Table columns should be expanded on load ?"
                 }
             }
         },

--- a/src/providers/sidebar-provider/sidebar-tree-items.ts
+++ b/src/providers/sidebar-provider/sidebar-tree-items.ts
@@ -9,6 +9,7 @@ import {
   window,
 } from 'vscode';
 import DatabaseInterface from './../../api/interface/database-interface';
+import ConfigManager = require('./../../api/config-manager');
 
 export class SidebarDatabase extends TreeItem {
   public iconPath = {
@@ -31,6 +32,8 @@ export class SidebarDatabase extends TreeItem {
     this[key].addItem(item.isView ? new SidebarView(item) : new SidebarTable(item));
   }
 }
+
+const tableTreeItemsExpanded = ConfigManager.get('tableTreeItemsExpanded', true);
 
 export class SidebarDatabaseStructure extends TreeItem {
   public iconPath = {
@@ -64,7 +67,7 @@ export class SidebarTable extends TreeItem {
 
   public items: SidebarColumn[] = [];
   constructor(table: DatabaseInterface.Table) {
-    super(table.name, TreeItemCollapsibleState.Expanded);
+    super(table.name, tableTreeItemsExpanded === true ? TreeItemCollapsibleState.Expanded : TreeItemCollapsibleState.Collapsed);
     this.value = table.name;
     this.label = `${table.name} (${table.numberOfColumns} cols)`;
   }

--- a/src/providers/sidebar-provider/sidebar-tree-items.ts
+++ b/src/providers/sidebar-provider/sidebar-tree-items.ts
@@ -9,7 +9,7 @@ import {
   window,
 } from 'vscode';
 import DatabaseInterface from './../../api/interface/database-interface';
-import ConfigManager = require('./../../api/config-manager');
+import ConfigManager from './../../api/config-manager';
 
 export class SidebarDatabase extends TreeItem {
   public iconPath = {


### PR DESCRIPTION
Here's the pull request that adds a configuration option to enable or disable default expanding table columns on first load.

Related to issue https://github.com/mtxr/vscode-sqltools/issues/105