### PR TITLE
Languageserver: only listen on localhost

### DIFF
--- a/src/languageserver/http-server/index.ts
+++ b/src/languageserver/http-server/index.ts
@@ -135,7 +135,7 @@ namespace HTTPServer {
   const httpServer: http.Server = http.createServer(reqHandler);
   export function server(port: number = 5123): http.Server {
     if (!httpServer.listening) {
-      httpServer.listen(port, () => {
+      httpServer.listen(port, 'localhost', () => {
         Logger.log(`SQLTools http server is listening on port ${port}`);
       });
     }


### PR DESCRIPTION
An automated vuln scanner spotted an XSS on my machine due to this extension listening for connections from any address, and lack of escaping in the 404 handler.

I don't think that for the Languageserver usecase we need to listen on anything besides localhost (otherwise we might want to propagate the option)

Also see #113