### PR TITLE
Oracle: Add PK and FG properties

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,45 +6,47 @@
     {
       "label": "compile",
       "type": "npm",
-      "script": "compile",
+      "script": "compile"
     },
     {
       "label": "watch:compile",
       "type": "npm",
       "script": "watch",
-      "group":{
+      "group": {
         "kind": "build",
         "isDefault": true
       },
       "isBackground": true,
-      "problemMatcher": [{
-        "applyTo": "allDocuments",
-        "owner": "typescript",
-        "source": "webpack",
-        "fileLocation": "absolute",
-        "severity": "error",
-        "pattern": [
+      "problemMatcher": [
+        {
+          "applyTo": "allDocuments",
+          "owner": "typescript",
+          "source": "webpack",
+          "fileLocation": "absolute",
+          "severity": "error",
+          "pattern": [
             {
-                "regexp": "\\[tsl\\] ERROR in (.*)?\\((\\d+),(\\d+)\\)",
-                "file": 1,
-                "line": 2,
-                "column": 3
+              "regexp": "\\[tsl\\] ERROR in (.*)?\\((\\d+),(\\d+)\\)",
+              "file": 1,
+              "line": 2,
+              "column": 3
             },
             {
-                "regexp": "\\s*TS\\d+:\\s*(.*)",
-                "message": 1
+              "regexp": "\\s*TS\\d+:\\s*(.*)",
+              "message": 1
             }
-        ]
-      }],
-      "background": {
-        "activeOnStart": true,
-        "beginsPattern": {
-            "regexp": "Compilation (.*?)starting.+"
-        },
-        "endsPattern": {
-            "regexp": "Compilation (.*?)finished"
+          ],
+          "background": {
+            "activeOnStart": true,
+            "beginsPattern": {
+              "regexp": "Compilation (.*?)starting.+"
+            },
+            "endsPattern": {
+              "regexp": "Compilation (.*?)finished"
+            }
+          }
         }
-    }
+      ]
     }
   ]
 }

--- a/packages/core/dialect/oracle/index.ts
+++ b/packages/core/dialect/oracle/index.ts
@@ -24,7 +24,9 @@ export default class OracleDB extends GenericDialect<OracleDBLib.IConnection> im
   queries = queries
 
   private get lib(): typeof OracleDBLib {
-    return __non_webpack_require__('oracledb');
+    const oracledb = __non_webpack_require__('oracledb');    
+    oracledb.fetchAsString = [oracledb.DATE, oracledb.CLOB];    
+    return oracledb;
   }
 
   private get poolName(): string {

--- a/packages/core/dialect/oracle/index.ts
+++ b/packages/core/dialect/oracle/index.ts
@@ -139,6 +139,8 @@ export default class OracleDB extends GenericDialect<OracleDBLib.IConnection> im
               tableName: `${obj.TABLESCHEMA}.${obj.TABLENAME}`,
               tableSchema: obj.TABLESCHEMA,
               type: obj.TYPE,
+              isPk: obj.constraintType === 'P',
+              isFk: obj.constraintType === 'R'
             } as DatabaseInterface.TableColumn;
           });
       });


### PR DESCRIPTION
- added isPK and isFG property
- changed tables select to only tables owned by current user (https://github.com/mtxr/vscode-sqltools/issues/139). Selecting for all tables with addition to joining with constraints info takes quite some time for larger databases.
- bacground property in the tasks.json was in the wrong place
- fetch date and clob datatypes as string

@mtxr , icons are not visible in my case, is there anything else i should do to display them? Also when connecion is active, there is an icon missing in my case.