### PR TITLE
Fix icon paths (active db, pk, fk)

### DIFF
--- a/packages/core/dialect/oracle/index.ts
+++ b/packages/core/dialect/oracle/index.ts
@@ -139,8 +139,8 @@ export default class OracleDB extends GenericDialect<OracleDBLib.IConnection> im
               tableName: `${obj.TABLESCHEMA}.${obj.TABLENAME}`,
               tableSchema: obj.TABLESCHEMA,
               type: obj.TYPE,
-              isPk: obj.constraintType === 'P',
-              isFk: obj.constraintType === 'R'
+              isPk: obj.CONSTRAINTTYPE === 'P',
+              isFk: obj.CONSTRAINTTYPE === 'R'
             } as DatabaseInterface.TableColumn;
           });
       });

--- a/packages/plugins/connection-manager/explorer/tree-items.ts
+++ b/packages/plugins/connection-manager/explorer/tree-items.ts
@@ -52,7 +52,7 @@ export class SidebarConnection extends TreeItem {
 
     if (!SidebarConnection.icons) {
       SidebarConnection.icons = {
-        active: Uri.parse(`file://${this.context.asAbsolutePath('icons/database-active.svg')}`),
+        active: this.context.asAbsolutePath('icons/database-active.svg'),
         connected: {
           dark: this.context.asAbsolutePath('icons/database-dark.svg'),
           light: this.context.asAbsolutePath('icons/database-light.svg'),
@@ -219,8 +219,8 @@ export class SidebarColumn extends TreeItem {
           dark: this.context.asAbsolutePath('icons/column-dark.png'),
           light: this.context.asAbsolutePath('icons/column-light.png'),
         },
-        primaryKey: Uri.parse(`file://${this.context.asAbsolutePath('icons/pk.svg')}`),
-        foreignKey: Uri.parse(`file://${this.context.asAbsolutePath('icons/fk.svg')}`),
+        primaryKey: this.context.asAbsolutePath('icons/pk.svg'),
+        foreignKey: this.context.asAbsolutePath('icons/fk.svg'),
       }
     }
     this.updateIconPath();

--- a/packages/plugins/connection-manager/screens/provider.ts
+++ b/packages/plugins/connection-manager/screens/provider.ts
@@ -49,7 +49,7 @@ export default abstract class WebviewProvider<State = any> implements Disposable
           enableFindWidget: true,
         },
       );
-      this.panel.iconPath = Uri.parse(`file://${this.context.asAbsolutePath('icons/database-active.svg')}`);
+      this.panel.iconPath = this.context.asAbsolutePath('icons/database-active.svg');
       this.disposables.push(Disposable.from(this.panel));
       this.disposables.push(this.panel.webview.onDidReceiveMessage(this.onDidReceiveMessage, undefined, this.disposables));
       this.disposables.push(this.panel.onDidChangeViewState(({ webviewPanel }) => {


### PR DESCRIPTION
`Uri.parse('file...` is causing problems with icon paths .