### PR TITLE
Improve SQLite setup docs

### DIFF
--- a/docs/Connections/SQLite.md
+++ b/docs/Connections/SQLite.md
@@ -5,7 +5,14 @@
 - Node.js 6 or newer
 - Enable `sqltools.useNodeRuntime` setting, can be `true` or a path to the node runtime.
 
-> Extension automatically installs SQLite driver (sqlite@v4.0.6)
+```json
+// settings.json example
+{
+    "sqltools.useNodeRuntime": true
+}
+```
+
+> Extension automatically asks to install the SQLite driver (sqlite@v4.0.6)
 
 More information you cand find in [node-sqlite3](https://github.com/mapbox/node-sqlite3) repo: https://github.com/mapbox/node-sqlite3.
 


### PR DESCRIPTION
Adding more prominent documentation about SQLite setup that many people seem to miss regarding the `sqltools.useNodeRuntime` setting. Added a sample `settings.json`.