### PR TITLE
Add SSL example to Postgres docs

### DIFF
--- a/docs/Connections/postgresql.md
+++ b/docs/Connections/postgresql.md
@@ -44,6 +44,28 @@ PostgreSQL driver specific options can be passed using `pgOptions` settings.
 | ssl  | `null`  | See https://node-postgres.com/features/ssl |
 
 
+#### Example: Azure Postgres
+
+This example enables `SSL` for connecting to an Azure Postgres instance. 
+
+```
+{
+    "name": "PGSQL",
+    "server": "HOSTNAME.postgres.database.azure.com",
+    "dialect": "PostgreSQL",
+    "port": 5432,
+    "database": "dbnamehere",
+    "username": "username@hostname",
+    "askForPassword": false,
+    "password": "password",
+    "connectionTimeout": 15,
+    "pgOptions": {
+        "ssl": "true"
+    }
+}
+```
+
+
 ### 1.2 Alternative Connection Strings
 
 ConnectionStrings or connectionURIs are supported as defined in `node-postgres` library. See [Connection URI](https://node-postgres.com/features/connecting#connection-uri) for more information.


### PR DESCRIPTION
First up - awesome project thanks for all the hard work!

I hit a bit of a stumbling block around how to use the SSL option when connecting to an Azure Postgres DB. The [docs linked here](https://node-postgres.com/features/ssl) show how to specify a cert but I just need to ensure it was enabled. 

To help others I added a quick example to the docs - hope this is useful, let me know if it needs tweaking and no worries if you don't want to include. 