### PR TITLE
Amend the building guide

### DIFF
--- a/docs/Contributing/building.md
+++ b/docs/Contributing/building.md
@@ -1,3 +1,7 @@
+## Pre-requesites
+
+Make sure you have node, npm and yarn installed.
+
 ## Building
 
 Open VSCode and run the `watch:compile`. Leave it running during the development.


### PR DESCRIPTION
Added a little clarification for the building guide requiring yarn (with node and npm being more implicit, but still worth mentioning) to build successfully.