### PR TITLE
Cleanup from removed column and overlooked CONCAT

### DIFF
--- a/packages/core/dialect/mssql/queries.ts
+++ b/packages/core/dialect/mssql/queries.ts
@@ -98,10 +98,10 @@ SELECT
   f.specific_name AS name,
   f.routine_schema AS dbSchema,
   f.routine_catalog AS dbName,
-  (
-    ISNULL(f.routine_schema, '') +
-    ISNULL('.', '') +
-    ISNULL(f.routine_name, '')
+  concat(
+    f.routine_schema,
+    '.',
+    f.routine_name    
   ) as signature,
   COALESCE(STUFF
   (
@@ -123,7 +123,7 @@ SELECT
     ) +
     ISNULL('${TREE_SEP}', '') +
     ISNULL(f.specific_name, '')
-  ) AS tree
+  ) AS tree,
 FROM
   information_schema.routines AS f
   LEFT JOIN information_schema.parameters AS p ON (

--- a/packages/core/dialect/mssql/queries.ts
+++ b/packages/core/dialect/mssql/queries.ts
@@ -98,10 +98,10 @@ SELECT
   f.specific_name AS name,
   f.routine_schema AS dbSchema,
   f.routine_catalog AS dbName,
-  concat(
-    f.routine_schema,
-    '.',
-    f.routine_name    
+  (
+    ISNULL(f.routine_schema, '') +
+    ISNULL('.', '') +
+    ISNULL(f.routine_name, '')
   ) as signature,
   COALESCE(STUFF
   (
@@ -123,7 +123,7 @@ SELECT
     ) +
     ISNULL('${TREE_SEP}', '') +
     ISNULL(f.specific_name, '')
-  ) AS tree,
+  ) AS tree
 FROM
   information_schema.routines AS f
   LEFT JOIN information_schema.parameters AS p ON (

--- a/packages/core/dialect/mssql/queries.ts
+++ b/packages/core/dialect/mssql/queries.ts
@@ -99,10 +99,10 @@ SELECT
   f.specific_name AS name,
   f.routine_schema AS dbSchema,
   f.routine_catalog AS dbName,
-  concat(
-    f.routine_schema,
-    '.',
-    f.routine_name    
+  (
+    ISNULL(f.routine_schema, '') +
+    ISNULL('.', '') +
+    ISNULL(f.routine_name, '')
   ) as signature,
   COALESCE(STUFF(
     (ISNULL(', ' + p.data_type, '')), 1, 2, N''
@@ -121,7 +121,7 @@ SELECT
     ) +
     ISNULL('${TREE_SEP}', '') +
     ISNULL(f.specific_name, '')
-  ) AS tree,
+  ) AS tree
 FROM
   information_schema.routines AS f
   LEFT JOIN information_schema.parameters AS p ON (


### PR DESCRIPTION
Forgot to clean comma from removed column and the very CONCAT used as an example in #440, was not converted using the ISNULL() approach.