### PR TITLE
Remove call of getAffectedRowsCount

### DIFF
--- a/packages/core/dialect/mysql/xprotocol.ts
+++ b/packages/core/dialect/mysql/xprotocol.ts
@@ -68,7 +68,7 @@ export default class MySQLX extends GenericDialect<any> implements ConnectionDia
       return JSON.parse(JSON.stringify(mapped, cols));
     }
 
-    const queryInfo = await session.sql(query).execute(_result => results.push(toMappedRow(_result)), _meta => {
+    await session.sql(query).execute(_result => results.push(toMappedRow(_result)), _meta => {
       _meta.forEach(({ name }, i) => {
         cols.push(name);
         props[name] = {
@@ -80,13 +80,6 @@ export default class MySQLX extends GenericDialect<any> implements ConnectionDia
       });
     });
 
-    const affectedRows = queryInfo.getAffectedRowsCount();
-
-
-
-    if (affectedRows) {
-      messages.push(`${affectedRows} rows were affected.`);
-    }
     return {
       connId: this.getId(),
       cols,


### PR DESCRIPTION
Fix https://github.com/mtxr/vscode-sqltools/issues/447

A recent commit in @mysql/xdevapi (https://github.com/mysql/mysql-connector-nodejs/commit/a49b47d89e9710efc6cffd727072ceff37058a22#diff-0fe2d532ca52cfbcb0ee51b0a150d0bfL36) changed the return type of `SqlExecute` from [`Result`](https://dev.mysql.com/doc/dev/connector-nodejs/8.0/module-Result.html) to [`SqlResult`](https://dev.mysql.com/doc/dev/connector-nodejs/8.0/module-SqlResult.html). Since there's no api to get information of affected rows in `SqlResult`, I simply removed the logging of affected rows. 

----

Thank you for your contribution! 
Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
- [ ] You have made the needed changes to the docs
- [x] You have wrote a description of what is the purpose of this pull request above
