### PR TITLE
Add ability to specify a folder for session files

### DIFF
--- a/docs/src/pages/features/session-multiple-connections.mdx
+++ b/docs/src/pages/features/session-multiple-connections.mdx
@@ -20,6 +20,8 @@ You can use the setting `sqltools.autoOpenSessionFiles` to enable or disable ses
 
 If `sqltools.autoOpenSessionFiles` is enabled, every time you open a connection, a session file will be opened attached to the selected connection.
 
+In addition, you may specify a folder where session files are saved using the setting `sqltools.sessionFilesFolder`.
+
 Also, switching to files that are attached, the respective connection is automatically set as active.
 
 ![Auto Switch](https://raw.githubusercontent.com/mtxr/vscode-sqltools/master/docs/assets/auto-switching.gif)

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -822,6 +822,11 @@
                     "default": true,
                     "description": "Auto open session file when connect"
                 },
+                "sqltools.sessionFilesFolder": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Folder for session files to be saved in"
+                },
                 "sqltools.dependencyManager": {
                     "type": "object",
                     "description": "Dependency manager settings",

--- a/packages/plugins/connection-manager/extension.ts
+++ b/packages/plugins/connection-manager/extension.ts
@@ -144,6 +144,11 @@ export default class ConnectionManagerPlugin implements IExtensionPlugin {
     if (!baseFolder) {
       baseFolder = Uri.file(getDataPath(SESSION_FILES_DIRNAME));
     }
+
+    if (ConfigManager.sessionFilesFolder && ConfigManager.sessionFilesFolder != '') {
+      baseFolder = Uri.file(getDataPath(ConfigManager.sessionFilesFolder));
+    }
+
     const sessionFilePath = path.resolve(baseFolder.fsPath, getSessionBasename(conn.name));
     try {
       this.updateAttachedConnectionsMap(

--- a/packages/types/settings/index.d.ts
+++ b/packages/types/settings/index.d.ts
@@ -206,6 +206,13 @@ export declare interface ISettings {
    */
   autoOpenSessionFiles?: boolean;
   /**
+   * Folder for session files to be saved in
+   * @default ''
+   * @type {string}
+   * @memberof ISettings
+   */
+  sessionFilesFolder?: string;  
+  /**
    * Set environment variables to be passed to language server. Eg: ORACLE_HOME, PATH...
    * @default {}
    * @type {{ [id: string]: string }}

--- a/test/project.code-workspace
+++ b/test/project.code-workspace
@@ -31,6 +31,7 @@
     "sqltools.useNodeRuntime": true,
     "sqltools.sortColumns": "ordinalnumber",
     "sqltools.autoOpenSessionFiles": true,
+    "sqltools.sessionFilesFolder": "/tmp",
     "sqltools.results": {
       "limit": 100,
       "location": "next",


### PR DESCRIPTION
Addresses https://github.com/mtxr/vscode-sqltools/issues/497

Adds the ability to specify a folder for session files to be saved in when hitting `Ctrl-S` vs the root of the repo.

----

Thank you for your contribution! 
Before submitting this PR, please make sure:

- [X] Your code builds clean without any errors or warnings
- [X] You have made the needed changes to the docs
- [X] You have wrote a description of what is the purpose of this pull request above
