### PR TITLE
Fix Cassandra driver fail after creating UDF

### DIFF
--- a/packages/drivers/src/driver/cql/index.ts
+++ b/packages/drivers/src/driver/cql/index.ts
@@ -119,14 +119,7 @@ export default class CQL extends AbstractDriver<CassandraLib.Client, CassandraLi
           cols,
           messages,
           query,
-          results: result.rows ? result.rows.map((row) => {
-            Object.entries(row).forEach(([key, value]) => {
-              if (typeof value === 'object') {
-                row[key] = JSON.stringify(value);
-              }
-            });
-            return row;
-          }) : [],
+          results: result.rows || [],
         };
         results.push(queryresult);
       } catch (e) {
@@ -192,7 +185,7 @@ export default class CQL extends AbstractDriver<CassandraLib.Client, CassandraLi
         name: obj.function_name,
         schema: obj.keyspace_name,
         database: '',
-        signature: obj.argument_types ? `(${obj.argument_types.join('; ')})` : '()',
+        signature: obj.argument_types ? `(${obj.argument_types.join(',')})` : '()',
         args: obj.argument_names,
         resultType: obj.return_type,
         source: obj.body,

--- a/test/docker/cql/1.create-some-stuff.sql
+++ b/test/docker/cql/1.create-some-stuff.sql
@@ -16,3 +16,9 @@ BEGIN BATCH
   INSERT INTO personal_data.contacts (first_name, last_name, city_id, age)
     VALUES ('Paul', 'McCartney', 637b67f3-d176-4dab-a9dc-5db8b4e2510a, 77);
 APPLY BATCH;
+
+CREATE OR REPLACE FUNCTION personal_data.avgState ( state tuple<int,bigint>, val int )
+  CALLED ON NULL INPUT RETURNS tuple<int,bigint> LANGUAGE java
+  AS 'if (val !=null) { state.setInt(0, state.getInt(0)+1);
+  state.setLong(1, state.getLong(1)+val.intValue()); }
+  return state;';

--- a/test/docker/cql/Dockerfile.cassandra
+++ b/test/docker/cql/Dockerfile.cassandra
@@ -1,0 +1,5 @@
+FROM cassandra
+
+RUN sed -i 's/start_rpc/start_rpc enable_user_defined_functions/' /usr/local/bin/docker-entrypoint.sh
+RUN sed -i 's/enable_user_defined_functions: false/enable_user_defined_functions: true/' /etc/cassandra/cassandra.yaml
+ENV CASSANDRA_ENABLE_USER_DEFINED_FUNCTIONS=true

--- a/test/docker/cql/docker-compose.yml
+++ b/test/docker/cql/docker-compose.yml
@@ -3,6 +3,9 @@ version: '2.1'
 
 services:
   db_cassandra:
+    build:
+      context: '.'
+      dockerfile: Dockerfile.cassandra
     container_name: sqltools_cql_cassandra
     image: cassandra
     restart: unless-stopped

--- a/test/package.json
+++ b/test/package.json
@@ -2,7 +2,7 @@
   "name": "@sqltools/test",
   "private": true,
   "scripts": {
-    "up": "docker-compose -f docker/docker-compose.yml up -d",
+    "up": "docker-compose -f docker/docker-compose.yml up --build -d",
     "up:mysql": "yarn run up mysql",
     "up:mssql": "yarn run up mssql",
     "up:mysqlv5": "yarn run up mysqlv5",


### PR DESCRIPTION
There was some special logic in the CQL driver code that turned all objects
into strings. This would cause an error when an array (treated as an object
in Javascript) function was called; which would only happen when the
database had a user-defined function (UDF).

This commit removes this logic and adapts the Docker tests to include a
UDF.

Closes #495

----

Thank you for your contribution! 
Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] You have made the needed changes to the docs
- [x] You have wrote a description of what is the purpose of this pull request above
