### PR TITLE
Respect global telemetry.enableTelemetry setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,5 +91,3 @@ See changelog [here](https://vscode-sqltools.mteixeira.dev/changelog)
 ## Feedback
 
 Please provide feedback through the [GitHub Issue](https://github.com/mtxr/vscode-sqltools/issues) system.
-
-By default we collect anonymous data like stacktraces to fix to errors/bugs. You can always opt-out.

--- a/docs/src/pages/index.mdx
+++ b/docs/src/pages/index.mdx
@@ -94,5 +94,3 @@ See changelog [here](https://vscode-sqltools.mteixeira.dev/changelog)
 ## Feedback
 
 Please provide feedback through the [GitHub Issue](https://github.com/mtxr/vscode-sqltools/issues) system.
-
-By default we collect anonymous data like stacktraces to fix to errors/bugs. You can always opt-out.

--- a/packages/core/config-manager.ts
+++ b/packages/core/config-manager.ts
@@ -1,3 +1,4 @@
+import { workspace } from 'vscode';
 import { ISettings as ISettingsProps } from '@sqltools/types';
 import { InvalidActionError } from '@sqltools/core/exception';
 
@@ -43,6 +44,7 @@ const handler = {
     if (prop === 'update') return update;
     if (prop === 'get') return get;
     if (prop === 'addOnUpdateHook') return addOnUpdateHook;
+    if (prop === 'telemetry') return !!settings.telemetry && workspace.getConfiguration('telemetry').get('enableTelemetry', false));
     if (prop in settings && typeof settings[prop] !== 'undefined') return settings[prop];
     if (settings.inspect) {
       const data = settings.inspect(prop) || { defaultValue: undefined };

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -425,8 +425,8 @@
                 },
                 "sqltools.telemetry": {
                     "type": "boolean",
-                    "default": true,
-                    "description": "Help SQLTools development. You can opt-out any time."
+                    "default": false,
+                    "description": "Help SQLTools development. You can opt-in any time."
                 },
                 "sqltools.showStatusbar": {
                     "type": "boolean",


### PR DESCRIPTION
In the EU GDPR mandates that _all_ user data collection is opt-in.
This is currently not the case, and additionally sqltools does not
respect the global `telemetry.enableTelemetry` setting. The latter is
used by VS Code itself, and associated official extensions. Also some
bigger extensions, like GitLens respects that.

This fixes #90, again, regressed in:

https://github.com/mtxr/vscode-sqltools/commit/b13c8d7027246d908f7bcb32bccf5a5daff52e79

----

Thank you for your contribution! 
Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] You have made the needed changes to the docs
- [x] You have wrote a description of what is the purpose of this pull request above
