### PR TITLE
Oracle DB: Improve display of RAW columns

### DIFF
--- a/packages/drivers/src/driver/oracle/index.ts
+++ b/packages/drivers/src/driver/oracle/index.ts
@@ -24,7 +24,7 @@ export default class OracleDB extends AbstractDriver<OracleDBLib.Connection, Ora
 
   private get lib(): typeof OracleDBLib {
     const oracledb = sqltoolsRequire('oracledb');
-    oracledb.fetchAsString = [oracledb.DATE, oracledb.CLOB, oracledb.NUMBER];
+    oracledb.fetchAsString = [oracledb.DATE, oracledb.CLOB, oracledb.NUMBER, oracledb.DB_TYPE_RAW];
     return oracledb;
   }
 


### PR DESCRIPTION
Similar to #344, except for Oracle DB.

```sql
SELECT HEXTORAW('67453E129BE8D312A456426655440000') FROM DUAL;
```

**Before**

```
{
  "data": [
    103,
    69,
    62,
    18,
    155,
    232,
    211,
    18,
    164,
    86,
    66,
    102,
    85,
    68,
    0,
    0
  ],
  "type": "Buffer"
}
```

**After**

```
67453E129BE8D312A456426655440000
```

Format is the same as Oracle SQL Developer's.
