### PR TITLE
Add support to legacy CQL schemas

### DIFF
--- a/packages/drivers/src/driver/cql/index.ts
+++ b/packages/drivers/src/driver/cql/index.ts
@@ -3,6 +3,7 @@ import { IConnectionDriver, NSDatabase } from '@sqltools/types';
 import * as Utils from '@sqltools/core/utils';
 import AbstractDriver from '../../lib/abstract';
 import Queries from './queries';
+import LegacyQueries from './legacy/queries';
 import { TREE_SEP } from '@sqltools/core/constants';
 
 interface CQLBatch {
@@ -11,8 +12,12 @@ interface CQLBatch {
   options: CassandraLib.QueryOptions,
 }
 
-export default class CQL extends AbstractDriver<CassandraLib.Client, CassandraLib.ClientOptions> implements IConnectionDriver {
+export default class CQL
+  extends AbstractDriver<CassandraLib.Client, CassandraLib.ClientOptions>
+  implements IConnectionDriver
+{
   queries = Queries;
+  isLegacy = false;
 
   public async open() {
     if (this.connection) {
@@ -22,7 +27,10 @@ export default class CQL extends AbstractDriver<CassandraLib.Client, CassandraLi
     const clientOptions: CassandraLib.ClientOptions = {
       contactPoints: [this.credentials.server],
       keyspace: this.credentials.database ? this.credentials.database : undefined,
-      authProvider: new CassandraLib.auth.PlainTextAuthProvider(this.credentials.username, this.credentials.password),
+      authProvider: new CassandraLib.auth.PlainTextAuthProvider(
+        this.credentials.username,
+        this.credentials.password
+      ),
       protocolOptions: {
         port: this.credentials.port,
       },
@@ -37,6 +45,13 @@ export default class CQL extends AbstractDriver<CassandraLib.Client, CassandraLi
     const conn = new CassandraLib.Client(clientOptions);
     await conn.connect();
     this.connection = Promise.resolve(conn);
+    // Check for modern schema support
+    const results = await this.query('SELECT keyspace_name FROM system_schema.tables LIMIT 1');
+    if (results[0].error) {
+      this.log.extend('info')('Remote Cassandra database is in legacy mode');
+      this.queries = LegacyQueries;
+      this.isLegacy = true;
+    }
     return this.connection;
   }
 
@@ -56,7 +71,9 @@ export default class CQL extends AbstractDriver<CassandraLib.Client, CassandraLi
     const cqlQueries: (string|CQLBatch)[] = [];
     for (let i = 0; i < queries.length; i++) {
       const query = queries[i];
-      const found = query.match(/^BEGIN\s+(UNLOGGED\s+|COUNTER\s+)?BATCH\s+(?:USING\s+TIMESTAMP\s+(\d+)\s+)?([\s\S]+)$/i);
+      const found = query.match(
+        /^BEGIN\s+(UNLOGGED\s+|COUNTER\s+)?BATCH\s+(?:USING\s+TIMESTAMP\s+(\d+)\s+)?([\s\S]+)$/i
+      );
 
       if (found) {
         const options: CassandraLib.QueryOptions = {};
@@ -141,12 +158,19 @@ export default class CQL extends AbstractDriver<CassandraLib.Client, CassandraLi
   }
 
   public async getTables(): Promise<NSDatabase.ITable[]> {
-    const [queryResults, numberOfColumnsResults] = await this.query(this.queries.fetchTables);
-    const numberOfColumnsMap: {string: {string: number}} = numberOfColumnsResults.results.reduce((prev, curr) => prev.concat(curr), []).reduce((acc, obj: any) => {
+    const [queryResults, columnsResults] = await this.query(this.queries.fetchTables);
+    const numberOfColumnsMap: {string: {string: number}} = columnsResults.results
+      .reduce((prev, curr) => prev.concat(curr), [])
+      .reduce((acc: {string: {string: number}}, obj: any) =>
+    {
       if (typeof acc[obj.keyspace_name] === 'undefined') {
         acc[obj.keyspace_name] = {};
       }
-      acc[obj.keyspace_name][obj.table_name] = parseInt(JSON.parse(obj.count), 10);
+      if (typeof acc[obj.keyspace_name][obj.table_name] === 'undefined') {
+        acc[obj.keyspace_name][obj.table_name] = 1;
+      } else {
+        acc[obj.keyspace_name][obj.table_name] += 1;
+      }
       return acc;
     }, {});
     return queryResults.results.reduce((prev, curr) => prev.concat(curr), []).map((obj: any) => {
@@ -154,7 +178,8 @@ export default class CQL extends AbstractDriver<CassandraLib.Client, CassandraLi
         name: obj.table_name,
         isView: false,
         tableSchema: obj.keyspace_name,
-        numberOfColumns: numberOfColumnsMap[obj.keyspace_name] ? numberOfColumnsMap[obj.keyspace_name][obj.table_name] : undefined,
+        numberOfColumns: numberOfColumnsMap[obj.keyspace_name] &&
+          numberOfColumnsMap[obj.keyspace_name][obj.table_name],
         tree: [obj.keyspace_name, 'tables', obj.table_name].join(TREE_SEP)
       };
       return table;
@@ -167,7 +192,7 @@ export default class CQL extends AbstractDriver<CassandraLib.Client, CassandraLi
       const column: NSDatabase.IColumn = {
         columnName: obj.column_name,
         tableName: obj.table_name,
-        type: obj.type,
+        type: this.isLegacy ? this.mapLegacyTypeToRegularType(obj.type) : obj.type,
         isNullable: obj.kind === 'regular',
         isPk: obj.kind !== 'regular',
         isPartitionKey: obj.kind === 'partition_key',
@@ -176,6 +201,17 @@ export default class CQL extends AbstractDriver<CassandraLib.Client, CassandraLi
       };
       return column;
     });
+  }
+
+  /**
+   * Turns a legacy Cassandra validator into a human-readable type. Examples:
+   * - 'org.apache.cassandra.db.marshal.Int32Type' becomes 'Int32'
+   * - 'org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.UTF8Type)'
+   *   becomes 'Set(UTF8)'
+   * @param legacyType
+   */
+  private mapLegacyTypeToRegularType(legacyType: string): string {
+    return legacyType.replace(/\b\w+\.|Type\b/g, '');
   }
 
   public async getFunctions(): Promise<NSDatabase.IFunction[]> {

--- a/packages/drivers/src/driver/cql/legacy/queries.ts
+++ b/packages/drivers/src/driver/cql/legacy/queries.ts
@@ -1,0 +1,23 @@
+import { IBaseQueries } from '@sqltools/types';
+
+export default {
+  describeTable: `
+    SELECT * FROM system.schema_columnfamilies
+    WHERE keyspace_name = ':keyspace'
+    AND columnfamily_name = ':table'`,
+  fetchColumns: `
+    SELECT keyspace_name, columnfamily_name AS table_name,
+    column_name, type AS kind, validator AS type
+    FROM system.schema_columns`,
+  fetchRecords: `SELECT * FROM :keyspace.:table LIMIT :limit`,
+  fetchTables: `
+    SELECT keyspace_name, columnfamily_name AS table_name
+    FROM system.schema_columnfamilies;
+    SELECT keyspace_name, columnfamily_name AS table_name
+    FROM system.schema_columns`,
+  fetchFunctions: `
+    SELECT keyspace_name, function_name,
+    argument_names, argument_types,
+    return_type, body
+    FROM system.schema_functions`,
+} as IBaseQueries;

--- a/packages/drivers/src/driver/cql/queries.ts
+++ b/packages/drivers/src/driver/cql/queries.ts
@@ -5,12 +5,19 @@ export default {
     SELECT * FROM system_schema.tables
     WHERE keyspace_name = ':keyspace'
     AND table_name = ':table'`,
-  fetchColumns: `SELECT * FROM system_schema.columns`,
+  fetchColumns: `
+    SELECT keyspace_name, table_name,
+    column_name, kind, type
+    FROM system_schema.columns`,
   fetchRecords: `SELECT * FROM :keyspace.:table LIMIT :limit`,
   fetchTables: `
-    SELECT * FROM system_schema.tables;
-    SELECT keyspace_name, table_name, COUNT(*)
-    FROM system_schema.columns
-    GROUP BY keyspace_name, table_name`,
-  fetchFunctions: `SELECT * FROM system_schema.functions`,
+    SELECT keyspace_name, table_name
+    FROM system_schema.tables;
+    SELECT keyspace_name, table_name
+    FROM system_schema.columns`,
+  fetchFunctions: `
+    SELECT keyspace_name, function_name,
+    argument_names, argument_types,
+    return_type, body
+    FROM system_schema.functions`,
 } as IBaseQueries;

--- a/test/docker/cql/Dockerfile.cassandra
+++ b/test/docker/cql/Dockerfile.cassandra
@@ -1,4 +1,4 @@
-FROM cassandra
+FROM cassandra:latest
 
 RUN sed -i 's/start_rpc/start_rpc enable_user_defined_functions/' /usr/local/bin/docker-entrypoint.sh
 RUN sed -i 's/enable_user_defined_functions: false/enable_user_defined_functions: true/' /etc/cassandra/cassandra.yaml

--- a/test/docker/cql/docker-compose.yml
+++ b/test/docker/cql/docker-compose.yml
@@ -7,14 +7,20 @@ services:
       context: '.'
       dockerfile: Dockerfile.cassandra
     container_name: sqltools_cql_cassandra
-    image: cassandra
     restart: unless-stopped
     ports:
       - '9043:9042'
-  
+
   db_scylla:
     container_name: sqltools_cql_scylla
     image: scylladb/scylla
     restart: unless-stopped
     ports:
       - '9044:9042'
+
+  db_cassandra_legacy:
+    container_name: sqltools_cql_cassandra_legacy
+    image: cassandra:2.2.14
+    restart: unless-stopped
+    ports:
+      - '9045:9042'

--- a/test/docker/docker-compose.yml
+++ b/test/docker/docker-compose.yml
@@ -29,3 +29,7 @@ services:
       extends:
         file: ./cql/docker-compose.yml
         service: db_scylla
+    cql_cassandra_legacy:
+      extends:
+        file: ./cql/docker-compose.yml
+        service: db_cassandra_legacy

--- a/test/package.json
+++ b/test/package.json
@@ -9,8 +9,9 @@
     "up:mysql_xprotocol": "yarn run up mysql_xprotocol",
     "up:oracle": "echo 'Oracle docker image currently not working'",
     "up:pgsql": "yarn run up pgsql",
-    "up:cql_cassandra": "yarn run up cql_cassandra",
+    "up:cql_cassandra": "docker pull cassandra:latest && yarn run up cql_cassandra",
     "up:cql_scylla": "yarn run up cql_scylla",
+    "up:cql_cassandra_legacy": "yarn run up cql_cassandra_legacy",
     "preup:mysql": "bash ./docker/mysql/prepare.sh"
   }
 }

--- a/test/project.code-workspace
+++ b/test/project.code-workspace
@@ -223,6 +223,17 @@
         "server": "localhost",
         "username": "cassandra",
         "group": "CQL"
+      },
+      {
+        "askForPassword": false,
+        "connectionTimeout": 15,
+        "driver": "Cassandra",
+        "name": "CQL Cassandra Legacy",
+        "password": "cassandra",
+        "port": 9045,
+        "server": "localhost",
+        "username": "cassandra",
+        "group": "CQL"
       }
     ],
     "sqltools.languageServerEnv": {


### PR DESCRIPTION
Upon connection to a CQL database, a query is run to check for compatibility
with a modern schema. If not found, compatibility with Cassandra versions prior
to 3.0 is assumed. This includes making the correct schema queries,
validator-to-type transformation, and not using `GROUP BY` to count columns
per table.

Aside from that, this commit includes improvements to driver code readability
and makes all columns explicit in queries.

Fixes #548

----

Thank you for your contribution! 
Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] You have made the needed changes to the docs
- [x] You have wrote a description of what is the purpose of this pull request above
