### PR TITLE
Added enum for sqltools.format.reservedWordCase

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -478,6 +478,11 @@
                                 "string",
                                 "null"
                             ],
+                            "enum": [
+                                "upper",
+                                "lower",
+                                "null"
+                            ],
                             "default": null,
                             "description": "Reserverd word case"
                         },


### PR DESCRIPTION
This PR adds autocomplete support for `sqltools.format.reservedWordCase` settings. 

```json
"enum": [
     "upper",
     "lower",
     "null"
]
```
----

- [x] Your code builds clean without any errors or warnings
- [x] You have made the needed changes to the docs
- [x] You have written a description of what is the purpose of this pull request above
