### PR TITLE
Sort MySQL databases alphabetically

### DIFF
--- a/packages/driver.mysql/src/ls/queries.ts
+++ b/packages/driver.mysql/src/ls/queries.ts
@@ -108,6 +108,8 @@ SELECT
   'database' as "detail"
 FROM information_schema.schemata
 WHERE schema_name NOT IN ('information_schema', 'performance_schema', 'sys', 'mysql')
+ORDER BY
+  schema_name
 `;
 
 export const searchTables: IBaseQueries['searchTables'] = queryFactory`


### PR DESCRIPTION
When setting up a MySQL connection, the order of the databases in the drop down list is not sorted. This simply orders the list
alphabetically to quickly find the desired database if one connection has multiple databases associated with it. 

----

Thank you for your contribution! 
Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] You have made the needed changes to the docs (N/A)
- [x] You have written a description of what is the purpose of this pull request above
