### PR TITLE
Fix the path to .d.ts

### DIFF
--- a/packages/formatter/package.json
+++ b/packages/formatter/package.json
@@ -4,7 +4,7 @@
   "description": "Formats SQL queries. Part of SQLTools",
   "license": "MIT",
   "main": "./lib/sqlFormatter.js",
-  "types": "./lib/index.d.ts",
+  "types": "./lib/sqlFormatter.d.ts",
   "private": false,
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
package.json of @sqltools/formatter has an incorrect path to .d.ts file. This PR fixes that.

----

Thank you for your contribution! 
Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] You have made the needed changes to the docs
- [x] You have written a description of what is the purpose of this pull request above
