### PR TITLE
Fix README for sqlFormatter package

### DIFF
--- a/packages/formatter/README.md
+++ b/packages/formatter/README.md
@@ -21,7 +21,7 @@ yarn add @sqltools/formatter
 ## Usage
 
 ```ts
-import sqlFormatter from 'sql-formatter';
+import sqlFormatter from '@sqltools/formatter';
 
 console.log(sqlFormatter.format('SELECT * FROM table1'));
 ```


### PR DESCRIPTION
Fix README import usage for `@sqltools/formatter` package. Details see #733 

----

Thank you for your contribution! 
Before submitting this PR, please make sure:

- [ ] Your code builds clean without any errors or warnings
- [x] You have made the needed changes to the docs
- [x] You have written a description of what is the purpose of this pull request above
