### PR TITLE
Truncate query text not to explode result tab

### DIFF
--- a/packages/plugins/connection-manager/screens/results.ts
+++ b/packages/plugins/connection-manager/screens/results.ts
@@ -98,7 +98,8 @@ class ResultsWebview extends WebviewProvider<QueryResultsState> {
       let suffix = 'query results';
       if (payload && payload.length > 0) {
         if (payload.length === 1) {
-          suffix = payload[0].label ? payload[0].label : payload[0].query.replace(/(\r?\n\s*)/gim, ' ');
+          let truncatedQuery = payload[0].query.length > 16 ? `${payload[0].query.substring(0, 16)}...` : payload[0].query;
+          suffix = payload[0].label ? payload[0].label : truncatedQuery.replace(/(\r?\n\s*)/gim, ' ');
         } else {
           suffix = 'multiple query results';
         }


### PR DESCRIPTION
When the result opens, the entire query text is pasted into the tab label. It makes it extremely annoying to use as even to find the close tab button, one has to scroll horizontally the entire length of the query.
Below screenshot before

<img width="1016" alt="image" src="https://user-images.githubusercontent.com/6072498/111671094-db9ca180-8818-11eb-9780-00dffa631a66.png">


and after

<img width="1015" alt="image" src="https://user-images.githubusercontent.com/6072498/111671295-19012f00-8819-11eb-830a-cb53c5c8651a.png">
