### PR TITLE
Use pg_tables to fix #604

### DIFF
--- a/packages/driver.pg/src/ls/queries.ts
+++ b/packages/driver.pg/src/ls/queries.ts
@@ -215,13 +215,14 @@ SELECT
   schema_name AS schema,
   '${ContextValue.SCHEMA}' as "type",
   'group-by-ref-type' as "iconId",
-  catalog_name as database
-FROM information_schema.schemata
-WHERE
-  schema_name !~ '^pg_'
-  AND schema_name <> 'information_schema'
-  AND catalog_name = '${p => p.database}'
-`;
+  '${p => p.database}' as database
+FROM (
+  SELECT DISTINCT(schemaname) AS schema_name
+  FROM pg_tables
+  WHERE
+    schemaname !~ '^pg_'
+    AND schemaname <> 'information_schema'
+)`;
 
 export default {
   describeTable,


### PR DESCRIPTION
This pull request fixed #604 by read schemas from pg_tables instead of information_schema.schemata.
The user needs to be the owner of a schema, or a member of a group that owns the schema,  to get any rows from information_schema.schemata.
This requirement is not realistic for non-superuser which will cause "Nothing here" under Schemas node.
I think read the schemas from pg_tables is enough.

----

Thank you for your contribution! 
Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] You have made the needed changes to the docs
- [x] You have written a description of what is the purpose of this pull request above
