### PR TITLE
bugfix: MSSQL top-level databases

### DIFF
--- a/packages/driver.mssql/src/ls/queries.ts
+++ b/packages/driver.mssql/src/ls/queries.ts
@@ -110,7 +110,9 @@ SELECT name AS label,
   '${ContextValue.DATABASE}' AS "type",
   'database' AS "detail"
 FROM MASTER.dbo.sysdatabases
-WHERE name NOT IN ('master', 'model', 'msdb', 'tempdb')
+WHERE
+  name NOT IN ('master', 'model', 'msdb', 'tempdb')
+  AND name = DB_NAME()
 `;
 export const searchTables: IBaseQueries['searchTables'] = queryFactory`
 SELECT


### PR DESCRIPTION
Fix for  #714.
Only show the database defined in the setup of MSSQL database connection.
This may also be an issue with [MySQL](https://github.com/mtxr/vscode-sqltools/blob/0c61f245d3afe0c7e89f8c39f3796b915005f93a/packages/driver.mysql/src/ls/queries.ts#L110).
