### PR TITLE
Add charset option to default connection

### DIFF
--- a/packages/driver.mysql/src/ls/default.ts
+++ b/packages/driver.mysql/src/ls/default.ts
@@ -34,6 +34,7 @@ export default class MySQLDefault extends AbstractDriver<MySQLLib.Pool, MySQLLib
       dateStrings: true,
       bigNumberStrings: true,
       supportBigNumbers: true,
+      charset: 'utf8mb4_general_ci',
       ...mysqlOptions
     });
 


### PR DESCRIPTION
By merging this you would achieve the ability to insert utf8 mb4 characters, such as emojii when using this vscode plugin. See #925 for reproducible case.

Closes #925 

----

Thank you for your contribution! 
Before submitting this PR, please make sure:

- [X] Your code builds clean without any errors or warnings
- [X] You have made the needed changes to the docs
- [X] You have written a description of what is the purpose of this pull request above
