### PR TITLE
feat(formatter): added support for postgres c-style escape strings

### DIFF
--- a/packages/formatter/src/core/Tokenizer.ts
+++ b/packages/formatter/src/core/Tokenizer.ts
@@ -91,6 +91,7 @@ export default class Tokenizer {
   // 3. double quoted string using "" or \" to escape
   // 4. single quoted string using '' or \' to escape
   // 5. national character quoted string using N'' or N\' to escape
+  // 6. postgres character quoted string using E'' or e'' to escape
   createStringPattern(stringTypes) {
     const patterns = {
       '``': '((`[^`]*($|`))+)',
@@ -98,6 +99,7 @@ export default class Tokenizer {
       '""': '(("[^"\\\\]*(?:\\\\.[^"\\\\]*)*("|$))+)',
       "''": "(('[^'\\\\]*(?:\\\\.[^'\\\\]*)*('|$))+)",
       "N''": "((N'[^N'\\\\]*(?:\\\\.[^N'\\\\]*)*('|$))+)",
+      "E''": "(((E|e)'[^'\\\\]*(?:\\\\.[^'\\\\]*)*('|$))+)",
     };
 
     return stringTypes.map(t => patterns[t]).join('|');

--- a/packages/formatter/src/languages/StandardSqlFormatter.ts
+++ b/packages/formatter/src/languages/StandardSqlFormatter.ts
@@ -8,7 +8,7 @@ export default class StandardSqlFormatter extends AbstractFormatter {
       reservedTopLevelWords,
       reservedNewlineWords,
       reservedTopLevelWordsNoIndent,
-      stringTypes: [`""`, "N''", "''", '``', '[]'],
+      stringTypes: [`""`, "N''", "''", '``', '[]', "E''"],
       openParens: ['(', 'CASE'],
       closeParens: [')', 'END'],
       indexedPlaceholderTypes: ['?'],

--- a/packages/formatter/test/StandardSqlFormatter.test.ts
+++ b/packages/formatter/test/StandardSqlFormatter.test.ts
@@ -642,4 +642,25 @@ where id = $1`);
       UPDATE ON * TO 'user' @'%';
     `))
   });
+
+  it("formats postgres specific c-style escape sequences", function() {
+    expect(format("E'\\n'")).toBe("E'\\n'");
+    expect(format("E'\\d+'")).toBe("E'\\d+'");
+    expect(format("E'\n'")).toBe("E'\n'");
+    expect(format("E'foo\\'bar'")).toBe("E'foo\\'bar'");
+
+    // also support lower-case e
+    expect(format("e'\n'")).toBe("e'\n'");
+    // multiline escape sequence
+    expect(format(`E'\n
+    \\d+
+    '`)).toBe(`E'\n
+    \\d+
+    '`);
+
+    expect(format("e'\n' ='abc'")).toBe("e'\n' = 'abc'");
+
+    // only E or e should be treated as special escape sequence
+    expect(format("D'\n'")).toBe("D '\n'");
+  });
 });


### PR DESCRIPTION
Added support for formatting SQL with escape string constants
starting with E' or e'.
https://www.postgresql.org/docs/current/sql-syntax-lexical.html

Closes #680 

Describe here what is this PR about and what we are achieving merging this.

----

Thank you for your contribution! 
Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] You have made the needed changes to the docs
- [x] You have written a description of what is the purpose of this pull request above
