### PR TITLE
Fix Postgres @@ operator formatting

### DIFF
--- a/packages/formatter/src/core/Tokenizer.ts
+++ b/packages/formatter/src/core/Tokenizer.ts
@@ -39,7 +39,7 @@ export default class Tokenizer {
     this.WHITESPACE_REGEX = /^(\s+)/u;
     this.NUMBER_REGEX = /^((-\s*)?[0-9]+(\.[0-9]+)?|0x[0-9a-fA-F]+|0b[01]+|([a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}))\b/u;
     this.AMBIGUOS_OPERATOR_REGEX = /^(\?\||\?&)/u;
-    this.OPERATOR_REGEX = /^(!=|<>|>>|<<|==|<=|>=|!<|!>|\|\|\/|\|\/|\|\||~~\*|~~|!~~\*|!~~|~\*|!~\*|!~|:=|&&|@>|<@|#-|@|.)/u;
+    this.OPERATOR_REGEX = /^(!=|<>|>>|<<|==|<=|>=|!<|!>|\|\|\/|\|\/|\|\||~~\*|~~|!~~\*|!~~|~\*|!~\*|!~|:=|&&|@>|<@|#-|@@|@|.)/u;
     this.NO_SPACE_OPERATOR_REGEX = /^(::|->>|->|#>>|#>)/u;
 
     this.BLOCK_COMMENT_REGEX = /^(\/\*[^]*?(?:\*\/|$))/u;

--- a/packages/formatter/test/behavesLikeSqlFormatter.ts
+++ b/packages/formatter/test/behavesLikeSqlFormatter.ts
@@ -412,6 +412,7 @@ export default function behavesLikeSqlFormatter(language?: any) {
         expect(format("foo !~* 'hello'")).toBe("foo !~* 'hello'");
         expect(format("foo !~~* 'hello'")).toBe("foo !~~* 'hello'");
         expect(format("@ foo")).toBe("@ foo");
+        expect(format("tsvector @@ tsquery")).toBe("tsvector @@ tsquery");
         expect(format("foo << 2")).toBe("foo << 2");
         expect(format("foo >> 2")).toBe("foo >> 2");
         expect(format("|/ foo")).toBe("|/ foo");


### PR DESCRIPTION
Closes #803 "Formatter breaks postgres @@ syntax"

The issue describes the problem well. For reference, here's a [piece of Postgres' documentation mentioning the `@@` operator](https://www.postgresql.org/docs/12/functions-textsearch.html).

----

- [ ] Your code builds clean without any errors or warnings
  `yarn run start` is actually giving me trouble. But I can run the formatter tests fine. The change is so small, I think that should be enough.
- [x] You have made the needed changes to the docs
  No changes needed, just a little fix.
- [x] You have written a description of what is the purpose of this pull request above
