### PR TITLE
Update @sqltools/types package

### DIFF
--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -10,6 +10,10 @@ This package is part of [vscode-sqltools](https://vscode-sqltools.mteixeira.dev?
 
 # Changelog
 
+### v0.1.6
+
+- IBaseQueries.fetchDatabases() can optionally pass an MConnectionExplorer.IChildItem in versions after 0.23.0.
+
 ### v0.1.5
 
 - Allow IConnection to have any properties.
@@ -20,7 +24,7 @@ This package is part of [vscode-sqltools](https://vscode-sqltools.mteixeira.dev?
 
 ### v0.1.3
 
-- fixed `checkDependencies` being requred. It's optional
+- fixed `checkDependencies` being required. It's optional
 
 ### v0.1.2
 
@@ -32,4 +36,4 @@ This package is part of [vscode-sqltools](https://vscode-sqltools.mteixeira.dev?
 
 ### v0.1.0
 
-- First realease
+- First release

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -36,7 +36,7 @@ export interface IBaseQueries {
   fetchRecords: QueryBuilder<{ limit: number; offset: number; table: NSDatabase.ITable; }, any>;
   countRecords: QueryBuilder<{ table: NSDatabase.ITable; }, { total: number; }>;
   fetchSchemas?: QueryBuilder<NSDatabase.IDatabase, NSDatabase.ISchema>;
-  fetchDatabases?: QueryBuilder<never, NSDatabase.IDatabase>;
+  fetchDatabases?: QueryBuilder<never | MConnectionExplorer.IChildItem, NSDatabase.IDatabase>;
   fetchTables: QueryBuilder<NSDatabase.ISchema, NSDatabase.ITable>;
   searchTables: QueryBuilder<{ search: string, limit?: number }, NSDatabase.ITable>;
   searchColumns: QueryBuilder<{ search: string, tables: NSDatabase.ITable[], limit?: number }, NSDatabase.IColumn>;

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sqltools/types",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "SQLTools interfaces and types",
   "types": "index.d.ts",
   "main": "index.js",


### PR DESCRIPTION
In PR #938 I am allowing fetchDatabases to pass the connection item, so that the query can adapt to its context. This PR updates the @sqltools/types package so that PR can build without errors.
