### PR TITLE
Re enable codecov for formatter and fix releases workflow command

### DIFF
--- a/.github/workflows/test-formatter.yml
+++ b/.github/workflows/test-formatter.yml
@@ -48,6 +48,6 @@ jobs:
         name: package
         path: ./packages/formatter/*.tgz
 
-    # - uses: codecov/codecov-action@v1.0.2
-    #   with:
-    #     token: ${{secrets.CODECOV_TOKEN_FORMATTER}} #required
+    - uses: codecov/codecov-action@v1.0.2
+      with:
+        token: ${{secrets.CODECOV_TOKEN_FORMATTER}} #required

--- a/.github/workflows/upload-release-assets.yml
+++ b/.github/workflows/upload-release-assets.yml
@@ -37,11 +37,11 @@ jobs:
         CC: "gcc-4.9"
         DISPLAY: ":99.0"
       run: |
-        ./pack.drivers.sh
+        yarn run pack:all
 
     - name: Upload to Release
       uses: OmgImAlexis/upload-to-release@12da88e9f14252a5232be13ee9aadda64637c271
       with:
-        args: "*.vsix packages/*/*.vsix"
+        args: "*.vsix"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Close #924 .

GH branches setting was requiring an outdated version of a job that doesn't exist anymore (build (10.x)). Updating that setting get's PR workflow unblocked again

![CleanShot 2022-08-21 at 04 05 00](https://user-images.githubusercontent.com/707561/185779775-88e1398b-f9f1-4dc9-aa1f-7a79c00f5989.png)

Fixes also #942 since the file was removed in favor of npm scripts.

----

Thank you for your contribution! 
Before submitting this PR, please make sure:

- [ ] Your code builds clean without any errors or warnings
- [ ] You have made the needed changes to the docs
- [ ] You have written a description of what is the purpose of this pull request above
