### PR TITLE
disable codecov outside of main repo

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -68,7 +68,7 @@ jobs:
         path: ./coverage
         retention-days: 2
 
-    - uses: codecov/codecov-action@v1.0.2
-      if: github.event_name == 'push'
+    - uses: codecov/codecov-action@v3
+      if: github.repository == 'mtxr/vscode-sqltools'
       with:
-        token: ${{secrets.CODECOV_TOKEN}} #required
+        flags: "extension"

--- a/.github/workflows/test-formatter.yml
+++ b/.github/workflows/test-formatter.yml
@@ -48,6 +48,7 @@ jobs:
         name: package
         path: ./packages/formatter/*.tgz
 
-    - uses: codecov/codecov-action@v1.0.2
+    - uses: codecov/codecov-action@v3
+      if: github.repository == 'mtxr/vscode-sqltools'
       with:
-        token: ${{secrets.CODECOV_TOKEN_FORMATTER}} #required
+        flags: "formatter"


### PR DESCRIPTION
disable codecov outside of main repo after reading codecov docs.

token is not required for public repos. but forks shouldn't upload anything, so i'm checking if the repository is the main one