### PR TITLE
Fix destructure property 'name' of 'undefined' error (#723)

### DIFF
--- a/packages/driver.mysql/src/ls/default.ts
+++ b/packages/driver.mysql/src/ls/default.ts
@@ -84,6 +84,9 @@ export default class MySQLDefault extends AbstractDriver<MySQLLib.Pool, MySQLLib
               if (r.changedRows) {
                 messages.push(`${r.changedRows} rows were changed.`);
               }
+              if (fields) {
+                fields = fields.filter(field => typeof field !== 'undefined');
+              }
               return {
                 connId: this.getId(),
                 requestId,


### PR DESCRIPTION
MySQL driver would report `Cannot destructure property 'name' of 'undefined' as it is undefined` (see #723) if query did not return columns (e.g. a DROP or an INSERT)
