### PR TITLE
avoid infinity loop if auto install fails for drivers

### DIFF
--- a/packages/plugins/connection-manager/dependency-manager/extension.ts
+++ b/packages/plugins/connection-manager/dependency-manager/extension.ts
@@ -68,9 +68,7 @@ export default class DependencyManager implements IExtensionPlugin {
                 if (dep.args) args.push(...dep.args);
               })
               progress.report({ message: `Installing "${depNamesString.join(", ")}". Please wait till it finishes. Check the opened terminal for more info.` });
-              terminal.sendText(`${dependencyManagerSettings.packageManager} ${args.join(" ")}`);
-              terminal.show();
-              terminal.sendText("exit 0");
+              terminal.sendText(`${dependencyManagerSettings.packageManager} ${args.join(" ")} && exit 0`);
             });
             progress.report({ increment: 100, message: `Finished installing ${depNamesString.join(", ")}` });
           });


### PR DESCRIPTION
Describe here what is this PR about and what we are achieving merging this.

I realized that when installing some drivers if the npm install fails, the terminal auto closes making it harder for the users to provide feedback. Also that was cause the install flow to stay in a loop. 

This PR address this issue.

----

Thank you for your contribution! 
Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] You have made the needed changes to the docs
- [x] You have written a description of what is the purpose of this pull request above
