### PR TITLE
Handle SQLite driver's `${workspaceFolder:rootFolderName}/...` database path format correctly on Windows (#703)

### DIFF
--- a/packages/base-driver/README.md
+++ b/packages/base-driver/README.md
@@ -2,6 +2,14 @@
 
 This package is part of [vscode-sqltools](https://vscode-sqltools.mteixeira.dev/?umd_source=repository&utm_medium=readme&utm_campaign=base-driver) extension.
 
+## Creating icon
+
+PNG Images
+Size: 64x64px
+Default Icon: Opacity 100%, no margins and paddings
+Active icon: Opacity 100%, no margins and paddings, green (#00FF00) circle 24x24 bottom right
+Inactive icon: Opacity 50%, no margins and paddings
+
 ## Changelog
 
 ### v0.1.11

--- a/packages/base-driver/README.md
+++ b/packages/base-driver/README.md
@@ -2,15 +2,11 @@
 
 This package is part of [vscode-sqltools](https://vscode-sqltools.mteixeira.dev/?umd_source=repository&utm_medium=readme&utm_campaign=base-driver) extension.
 
-## Creating icon
-
-PNG Images
-Size: 64x64px
-Default Icon: Opacity 100%, no margins and paddings
-Active icon: Opacity 100%, no margins and paddings, green (#00FF00) circle 24x24 bottom right
-Inactive icon: Opacity 50%, no margins and paddings
-
 ## Changelog
+
+### v0.1.11
+
+- Fix `toAbsolutePath` for Windows by using `vscode-uri`.
 
 ### v0.1.9
 

--- a/packages/base-driver/package.json
+++ b/packages/base-driver/package.json
@@ -1,7 +1,11 @@
 {
   "name": "@sqltools/base-driver",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "SQLTools Base Driver",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,6 +40,7 @@
   "dependencies": {
     "@sqltools/types": "latest",
     "@sqltools/log": "latest",
+    "vscode-uri": "^3.0.3",
     "env-paths": "^2.2.0",
     "make-dir": "^3.1.0",
     "resolve": "^1.17.0",

--- a/packages/base-driver/src/index.ts
+++ b/packages/base-driver/src/index.ts
@@ -16,6 +16,7 @@ import sqltoolsRequire, { sqltoolsResolve } from './lib/require';
 import { createLogger } from '@sqltools/log';
 import path from 'path';
 import fs from 'fs';
+import {URI} from 'vscode-uri';
 
 export default abstract class AbstractDriver<ConnectionType extends any, DriverOptions extends any> implements IConnectionDriver {
   public log: ReturnType<typeof createLogger>;
@@ -118,7 +119,7 @@ export default abstract class AbstractDriver<ConnectionType extends any, DriverO
       if (workspaceName) {
         const workspaceFolders = await this.getWorkspaceFolders();
         const dbWorkspace = workspaceFolders.find(w => w.name === workspaceName);
-        fsPath = path.resolve(dbWorkspace.uri.replace(/^(\w+):\/\//, ''), fsPath.replace(/\$\{workspaceFolder:(.+)}/g, './'));
+        fsPath = path.resolve(URI.parse(dbWorkspace.uri, true).fsPath, fsPath.replace(/\$\{workspaceFolder:(.+)}/g, './'));
       }
     }
     return fsPath;

--- a/packages/driver.sqlite/package.json
+++ b/packages/driver.sqlite/package.json
@@ -63,7 +63,7 @@
     "ts": "tsc -p ."
   },
   "devDependencies": {
-    "@sqltools/base-driver": "latest",
+    "@sqltools/base-driver": "^0.1.11",
     "@types/sqlite3": "^3.1.8",
     "@types/vscode": "^1.42.0",
     "chokidar-cli": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7901,6 +7901,11 @@ vscode-test@^1.5.1:
     rimraf "^3.0.2"
     unzipper "^0.10.11"
 
+vscode-uri@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-3.0.3.tgz#a95c1ce2e6f41b7549f86279d19f47951e4f4d84"
+  integrity sha512-EcswR2S8bpR7fD0YPeS7r2xXExrScVMxg4MedACaWHEtx9ftCF/qHG1xGkolzTPcEmjTavCQgbVzHUIdTMzFGA==
+
 vue-class-component@7.2.3:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/vue-class-component/-/vue-class-component-7.2.3.tgz#a5b1abd53513a72ad51098752e2dedd499807cca"


### PR DESCRIPTION
The SQLite driver had been coded to transform an absolute path for a database file within the workspace, storing it in the connection definition with a `${workspaceFolder:rootFoldername}/` prefix instead. This is done so that if the connection definition is put in a source-controlled `XYZ.code-workspace` or `.vscode/settings.json` file and the database is also committed to source control then the connection will work regardless of where another developer places their pulled copy of the connection config file and the database.

However the mechanism wasn't working correctly on Windows, resulting in the symptoms described in #703.

This PR resolves the issue by publishing a corrected version 0.1.11 of [@sqltools/base-driver](https://www.npmjs.com/package/@sqltools/base-driver/v/0.1.11), then using that in driver.sqlite.

----

Thank you for your contribution! 
Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] You have made the needed changes to the docs
- [x] You have written a description of what is the purpose of this pull request above
