### PR TITLE
Fix some flakiness caused by PR #957

### DIFF
--- a/packages/extension/src/language-client/client.ts
+++ b/packages/extension/src/language-client/client.ts
@@ -23,12 +23,6 @@ export class SQLToolsLanguageClient implements ILanguageClient {
 
   private avoidRestart = false;
   constructor() {
-    this.onNotification(ExitCalledNotification, () => {
-      this.avoidRestart = true;
-    });
-
-    this.registerBaseNotifications();
-
     Config.addOnUpdateHook(async ({ event }) => {
       if (event.affectsConfig('useNodeRuntime')) {
         const res = await window.showWarningMessage('Use node runtime setting change. You must reload window to take effect.', 'Reload now');
@@ -63,8 +57,14 @@ export class SQLToolsLanguageClient implements ILanguageClient {
         return defaultErrorHandler.closed();
       },
     };
+    
+    this.onNotification(ExitCalledNotification, () => {
+      this.avoidRestart = true;
+    });
 
+    this.registerBaseNotifications();
   }
+
   public start() {
     return this.client.start();
   }
@@ -83,6 +83,7 @@ export class SQLToolsLanguageClient implements ILanguageClient {
     await this.client.onReady();
     return this.client.sendNotification.apply(this.client, arguments);
   }
+  
   public onNotification: LanguageClient['onNotification'] = async function () {
     await this.client.onReady();
     return this.client.onNotification.apply(this.client, arguments);
@@ -100,6 +101,7 @@ export class SQLToolsLanguageClient implements ILanguageClient {
           runtime = runtimePath;
         }
       } else {
+        log.info('Detecting node path (if this stalls check Terminal view for the stuck session and kill it)...');
         const nodePath = await detectNodePath();
         if (nodePath) {
           const message = `Node runtime auto-detected. Using ${nodePath}.`;

--- a/packages/extension/src/language-client/detect-node-path.ts
+++ b/packages/extension/src/language-client/detect-node-path.ts
@@ -9,11 +9,12 @@ const nodeRuntimeTmpFile = getDataPath(".node-runtime");
 const detectNodePath = async (): Promise<string | null> => {
   try {
     const terminal = window.createTerminal({ name: "detect node runtime" });
-    await new Promise<void>((resolve) => {
+    const shellExitCommand = await getShellExitCommand();
+    await new Promise<void>(async (resolve) => {
       window.onDidCloseTerminal((e => e.processId === terminal.processId && resolve()));
       const nodeCmd = `require("fs").writeFileSync("${nodeRuntimeTmpFile}", process.execPath)`;
       const nodeCmdWindows = nodeCmd.replace(/\\/g, '\\\\').replace(/\"/g, '\\"');
-      terminal.sendText(`node -e '${process.platform === 'win32' ? nodeCmdWindows : nodeCmd}' && ${getShellExitCommand()}`);
+      terminal.sendText(`node -e '${process.platform === 'win32' ? nodeCmdWindows : nodeCmd}' && ${shellExitCommand}`);
     })
     return fs.readFileSync(nodeRuntimeTmpFile).toString();
   } catch (error) {

--- a/packages/vscode/utils/get-shell-exit-cmd.ts
+++ b/packages/vscode/utils/get-shell-exit-cmd.ts
@@ -1,7 +1,23 @@
 import { env } from 'vscode';
 
-export default function getShellExitCommand(code = 0) {
-  const isPowerShell = env.shell.match(/[\\/]pwsh(\.exe)?$/g);
+export default async function getShellExitCommand(code = 0) {
+
+  // env.shell in 1.71 sometimes returns '' unexpectedly.
+  // Use a retry loop to try and overcome this.
+  let shell = '';
+  for (let attempt = 1; attempt <= 10; attempt++) {
+    shell = env.shell;
+    if (shell !== '') {
+      break;
+    }
+    await new Promise(c => setTimeout(c, 500));
+  }
+
+  if (shell === '') {
+    throw new Error('No env.shell retrieved despite retries');
+  }
+
+  const isPowerShell = shell.match(/[\\/]pwsh(\.exe)?$/g);
   if (isPowerShell) return `$(exit ${code})`;
   return `exit ${code}`;
 }


### PR DESCRIPTION
On Windows at least, the node path auto-detect changes from #957 were producing intermittent failures. One of these was caused by vscode.env.shell sometimes being empty, perhaps a consequence of being called very early in VS Code startup.
