### PR TITLE
Add `sqltools.results.reuseTabs` setting (#632)

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -436,7 +436,7 @@
         ],
         "configuration": {
             "type": "object",
-            "title": "SQLTools Settings",
+            "title": "SQLTools",
             "properties": {
                 "sqltools.disableReleaseNotifications": {
                     "type": "boolean",
@@ -449,7 +449,7 @@
                         "array"
                     ],
                     "default": [],
-                    "markdownDescription": "Name(s) of the connection to auto connect on start.",
+                    "markdownDescription": "Name(s) of the connection(s) to auto connect on start.",
                     "items": {
                         "type": "string"
                     }
@@ -750,66 +750,73 @@
                         }
                     }
                 },
-                "sqltools.results": {
+                "sqltools.results.limit": {
+                    "type": "number",
+                    "description": "Maximum number of records to return in results.",
+                    "default": 50
+                },
+                "sqltools.results.reuseTabs": {
+                    "type": "string",
+                    "description": "How requests reuse results tabs.",
+                    "default": "never",
+                    "enum": [
+                        "never",
+                        "connection"
+                    ],
+                    "enumDescriptions": [
+                        "Every request creates a new tab.",
+                        "There is a single tab for each connection."
+                    ]
+                },
+                "sqltools.results.location": {
+                    "type": [
+                        "string"
+                    ],
+                    "default": "next",
+                    "enum": [
+                        "next",
+                        "current",
+                        "end",
+                        "1",
+                        "2",
+                        "3",
+                        "4",
+                        "5",
+                        "6",
+                        "7",
+                        "8",
+                        "9"
+                    ],
+                    "enumDescriptions": [
+                        "New group if nothing open. Second group if currently active text editor is in first group. Otherwise third group.",
+                        "Current active group.",
+                        "The third group.",
+                        "First group.",
+                        "Second group.",
+                        "Third group.",
+                        "Fourth group.",
+                        "Fifth group.",
+                        "Sixth group.",
+                        "Seventh group.",
+                        "Eighth group.",
+                        "Ninth group."
+                    ],
+                    "markdownDescription": "Define which edit group the results tab should appear in. Empty groups are never created. For example, if setting is 4 but only one group currently exists then the first set of results will create a new group 2, the second a group 3 and the third and subsequent sets of results will appear in group 4."
+                },
+                "sqltools.results.customization": {
                     "type": "object",
+                    "description": "Properties that customize the appearance of results tables.",
                     "default": {},
                     "properties": {
-                        "limit": {
-                            "type": "number",
-                            "description": "Maximum number of records to return in results.",
-                            "default": 50
+                        "font-family": {
+                            "type": "string"
                         },
-                        "location": {
-                            "type": [
-                                "string",
-                                "number"
-                            ],
-                            "default": "next",
-                            "enum": [
-                                "next",
-                                "current",
-                                "end",
-                                1,
-                                2,
-                                3,
-                                4,
-                                5,
-                                6,
-                                7,
-                                8,
-                                9
-                            ],
-                            "enumDescriptions": [
-                                "New group if nothing open. Second group if currently active text editor is in first group. Otherwise third group.",
-                                "Current active group.",
-                                "The third group.",
-                                "First group.",
-                                "Second group.",
-                                "Third group.",
-                                "Fourth group.",
-                                "Fifth group.",
-                                "Sixth group.",
-                                "Seventh group.",
-                                "Eighth group.",
-                                "Ninth group."
-                            ],
-                            "markdownDescription": "Define which edit group the results tab should appear in. Empty groups are never created. For example, if setting is 4 but only one group currently exists then the first set of results will create a new group 2, the second a group 3 and the third and subsequent sets of results will appear in group 4."
+                        "font-size": {
+                            "type": "string"
                         },
-                        "customization": {
-                            "type": "object",
-                            "default": {},
-                            "properties": {
-                                "font-family": {
-                                    "type": "string"
-                                },
-                                "font-size": {
-                                    "type": "string"
-                                },
-                                "table-cell-padding": {
-                                    "type": "string",
-                                    "default": "2px 4px"
-                                }
-                            }
+                        "table-cell-padding": {
+                            "type": "string",
+                            "default": "2px 4px"
                         }
                     }
                 },

--- a/packages/plugins/connection-manager/extension.ts
+++ b/packages/plugins/connection-manager/extension.ts
@@ -506,7 +506,7 @@ export class ConnectionManagerPlugin implements IExtensionPlugin {
 
 
   private async _openResultsWebview(connId: string, reUseId: string) {
-    const requestId = reUseId || generateId();
+    const requestId = reUseId || Config.results.reuseTabs === 'connection' ? connId :  generateId();
     const view = this.resultsWebview.get(requestId);
     view.onDidDispose(() => {
       this.client.sendRequest(ReleaseResultsRequest, { connId, requestId });

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -494,12 +494,21 @@ export interface IResultsOptions {
   limit: number;
 
   /**
-   * Define where the results should show up. Use the defined strings or any number defined in https://code.visualstudio.com/api/references/vscode-api#ViewColumn
+   * Defines how results tabs are or are not reused
+   * @type {string}
+   * @default 'never'
+   * @memberof IResultsOptions
+   */
+  reuseTabs?: 'never' | 'connection';
+
+  /**
+   * Defines where the results should show up. Use the defined strings or any number defined in https://code.visualstudio.com/api/references/vscode-api#ViewColumn
    * @type {string}
    * @default 'next'
    * @memberof IResultsOptions
    */
   location?: 'current' | 'next' | 'end' | number;
+
   /**
    * Customize results screen CSS
    *

--- a/test/project.code-workspace
+++ b/test/project.code-workspace
@@ -22,13 +22,6 @@
     "sqltools.sortColumns": "ordinalnumber",
     "sqltools.autoOpenSessionFiles": true,
     "sqltools.sessionFilesFolder": "/tmp",
-    "sqltools.results": {
-      "limit": 100,
-      "location": "next",
-      "customization": {
-        "table-cell-padding": "2px 4px"
-      }
-    },
     "sqltools.format": {
       "reservedWordCase": "upper",
       "linesBetweenQueries": "preserve"
@@ -206,6 +199,7 @@
     "sqltools.debug": {
       "namespaces": "*"
     },
+    "sqltools.results.limit": 100,
     // "sqltools.trace.server": "verbose"
   },
   "extensions": {


### PR DESCRIPTION
This PR fixes #632 by adding a new `sqltools.results.reuseTabs` enum setting. Values are `never` (the default which retains current behaviour) and `connection` (which reuses a tab per connection).

As part of this work the other third-level settings of the `sqltools.results` object have been broken out into individual 3-part properties. This means they are mostly editable in the settings UI and display better in the web documentation. The exception is `sqltools.results.customization` which is still an object.

----

Thank you for your contribution! 
Before submitting this PR, please make sure:

- [X] Your code builds clean without any errors or warnings
- [X] You have made the needed changes to the docs
- [X] You have written a description of what is the purpose of this pull request above
