### PR TITLE
v0.25.1 - Default `sqltools.useNodeRuntime` to `false` (#972)

### DIFF
--- a/docs/src/pages/changelog.mdx
+++ b/docs/src/pages/changelog.mdx
@@ -7,6 +7,11 @@ route: /changelog
 
 ## v0.25
 
+### v0.25.1 - (Sep 16, 2022)
+
+- **Extension**
+  - Default `sqltools.useNodeRuntime` to `false` to resolve a startup failure affecting some 0.25.0 users.
+
 ### v0.25.0 - (Sep 15, 2022)
 
 - **Extension**

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -2,7 +2,7 @@
     "name": "sqltools",
     "displayName": "SQLTools",
     "description": "Database management done right. Connection explorer, query runner, intellisense, bookmarks, query history. Feel like a database hero!",
-    "version": "0.25.0",
+    "version": "0.25.1",
     "publisher": "mtxr",
     "license": "MIT",
     "preview": false,
@@ -851,7 +851,7 @@
                         "boolean",
                         "string"
                     ],
-                    "default": true,
+                    "default": false,
                     "description": "Enable node runtime usage."
                 },
                 "sqltools.languageServerEnv": {


### PR DESCRIPTION
https://github.com/mtxr/vscode-sqltools/pull/957/commits/859cbd355923a83c0d05d5100fe81c6740ffaea9 which landed in the 0.25.0 release is causing the SQLTools to hang during activation on some systems (see #972 for example).

This PR returns the default value of `sqltools.useNodeRuntime` to `false`. It will be published as a 0.25.1 recovery release ASAP.
