### PR TITLE
fix: fixes slow formatting of queries with large no. of lines

### DIFF
--- a/packages/formatter/src/core/Formatter.ts
+++ b/packages/formatter/src/core/Formatter.ts
@@ -4,7 +4,14 @@ import InlineBlock from './InlineBlock';
 import Params from './Params';
 import Tokenizer from './Tokenizer';
 
-const trimSpacesEnd = str => str.replace(/[ \t]+$/u, '');
+const spaceChars = [' ', '\t'];
+const trimSpacesEnd = (str: string) => {
+  let end = str.length - 1;
+  while (end >= 0 && spaceChars.includes(str[end])) {
+    end--;
+  }
+  return str.substring(0, end + 1);
+};
 
 export default class Formatter {
   private tokens: Token[] = [];


### PR DESCRIPTION
Related to #977

This change removes RegEx-based trimming to improve performance.
There may be other places where performance could be improved.
After this change, the query mentioned in #977 gets formatted in under 1s.

Describe here what is this PR about and what we are achieving merging this.

----

Thank you for your contribution! 
Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] You have made the needed changes to the docs
- [x] You have written a description of what is the purpose of this pull request above
