### PR TITLE
use ; as a statement separator

### DIFF
--- a/packages/extension/src/language-client/detect-node-path.ts
+++ b/packages/extension/src/language-client/detect-node-path.ts
@@ -14,7 +14,7 @@ const detectNodePath = async (): Promise<string | null> => {
       window.onDidCloseTerminal((e => e.processId === terminal.processId && resolve()));
       const nodeCmd = `require("fs").writeFileSync("${nodeRuntimeTmpFile}", process.execPath)`;
       const nodeCmdWindows = nodeCmd.replace(/\\/g, '\\\\').replace(/\"/g, '\\"');
-      terminal.sendText(`node -e '${process.platform === 'win32' ? nodeCmdWindows : nodeCmd}' && ${shellExitCommand}`);
+      terminal.sendText(`node -e '${process.platform === 'win32' ? nodeCmdWindows : nodeCmd}'; ${shellExitCommand}`);
     })
     return fs.readFileSync(nodeRuntimeTmpFile).toString();
   } catch (error) {


### PR DESCRIPTION
Hello. I get the following error in my vscode console on startup.
![image](https://user-images.githubusercontent.com/24884680/192139088-5145bda5-6861-4ab6-a1eb-df15e99b4cad.png)
The command seems to work more reliably if we use a ; as a statement separator instead of &&
