### PR TITLE
Recognize special assignment operator in function calls

### DIFF
--- a/packages/formatter/src/core/Tokenizer.ts
+++ b/packages/formatter/src/core/Tokenizer.ts
@@ -39,7 +39,7 @@ export default class Tokenizer {
     this.WHITESPACE_REGEX = /^(\s+)/u;
     this.NUMBER_REGEX = /^((-\s*)?[0-9]+(\.[0-9]+)?|0x[0-9a-fA-F]+|0b[01]+|([a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}))\b/u;
     this.AMBIGUOS_OPERATOR_REGEX = /^(\?\||\?&)/u;
-    this.OPERATOR_REGEX = /^(!=|<>|>>|<<|==|<=|>=|!<|!>|\|\|\/|\|\/|\|\||~~\*|~~|!~~\*|!~~|~\*|!~\*|!~|:=|&&|@>|<@|#-|@@|@|.)/u;
+    this.OPERATOR_REGEX = /^(!=|<>|>>|<<|==|<=|>=|!<|!>|\|\|\/|\|\/|\|\||~~\*|~~|!~~\*|!~~|~\*|!~\*|!~|:=|=>|&&|@>|<@|#-|@@|@|.)/u;
     this.NO_SPACE_OPERATOR_REGEX = /^(::|->>|->|#>>|#>)/u;
 
     this.BLOCK_COMMENT_REGEX = /^(\/\*[^]*?(?:\*\/|$))/u;

--- a/packages/formatter/test/behavesLikeSqlFormatter.ts
+++ b/packages/formatter/test/behavesLikeSqlFormatter.ts
@@ -370,6 +370,7 @@ export default function behavesLikeSqlFormatter(language?: any) {
         expect(format("foo !> bar")).toBe("foo !> bar");
         expect(format("foo && bar")).toBe("foo && bar");
         expect(format("foo := bar")).toBe("foo := bar");
+        expect(format("foo => bar")).toBe("foo => bar"); // Snowflake, TimescaleDB
     });
 
     it("formats logical operators", function() {


### PR DESCRIPTION
Fixes #764 and #893

Snowflake and TimescaleDB use => as assignment operator in certain situations. These changes will prevent it being split apart by a space. 