### PR TITLE
Fix `"linesBetweenQueries": "preserve"` formatting (#914)

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -551,11 +551,11 @@
                             ],
                             "enumDescriptions": [
                                 "Leave unchanged.",
-                                "1 line.",
-                                "2 lines.",
-                                "3 lines.",
-                                "4 lines.",
-                                "5 lines."
+                                "1 linebreak.",
+                                "2 linebreaks.",
+                                "3 linebreaks.",
+                                "4 linebreaks.",
+                                "5 linebreaks."
                             ],
                             "default": 1,
                             "description": "Adjust spacing between queries."

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -292,7 +292,7 @@
                 "category": "SQLTools Management"
             },
             {
-                "title": "Open settings",
+                "title": "Open Settings",
                 "command": "sqltools.openSettings",
                 "category": "SQLTools Management"
             },
@@ -307,7 +307,7 @@
                 "category": "SQLTools Sidebar"
             },
             {
-                "title": "Copy value(s)",
+                "title": "Copy Value(s)",
                 "command": "sqltools.copyTextFromTreeItem",
                 "category": "SQLTools Sidebar"
             },

--- a/packages/formatter/src/core/Formatter.ts
+++ b/packages/formatter/src/core/Formatter.ts
@@ -93,7 +93,7 @@ export default class Formatter {
       && /((\r\n|\n)(\r\n|\n)+)/u.test(token.value)
       && this.previousToken().value === ';'
     ) {
-      return query.replace(/(\n|\r\n)$/m, '') + token.value;
+      return query.replace(/(\n|\r\n)$/u, '') + token.value;
     }
     return query
   }

--- a/packages/formatter/test/StandardSqlFormatter.test.ts
+++ b/packages/formatter/test/StandardSqlFormatter.test.ts
@@ -504,6 +504,23 @@ where id = $1`);
         id INTEGER PRIMARY KEY,
         name VARCHAR(200) UNIQUE,
       );
+
+      CREATE TABLE bar (
+        id INTEGER PRIMARY KEY,
+        name VARCHAR(200) UNIQUE,
+      );
+
+      CREATE TABLE baz (
+        id INTEGER PRIMARY KEY,
+        name VARCHAR(200) UNIQUE,
+      );
+    `;
+    expect(format(input, { linesBetweenQueries: 'preserve' })).toEqual(input);
+    input = dedent`
+      CREATE TABLE foo (
+        id INTEGER PRIMARY KEY,
+        name VARCHAR(200) UNIQUE,
+      );
       CREATE TABLE bar (
         id INTEGER PRIMARY KEY,
         name VARCHAR(200) UNIQUE,


### PR DESCRIPTION
This PR fixes #914. See that issue for details.

It also improves the enumDescriptions for that setting to clarify that 1 means 1 linebreak (i.e. zero blank lines).

----

Thank you for your contribution! 
Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] You have made the needed changes to the docs
- [x] You have written a description of what is the purpose of this pull request above
