### PR TITLE
Runtime-detection warning gave wrong setting name (#1037)

### DIFF
--- a/packages/extension/src/language-client/detect-node-path.ts
+++ b/packages/extension/src/language-client/detect-node-path.ts
@@ -8,7 +8,7 @@ const nodeRuntimeTmpFile = getDataPath(".node-runtime");
 
 const detectNodePath = async (): Promise<string | null> => {
   const failureMessageTimer = setTimeout(() => {
-    window.showWarningMessage("Check Terminal view for an erroring 'detect node runtime' session. Capture details for investigation, then kill the terminal to continue SQLTools extension startup. Change the 'sqltools.detectNodeRuntime' setting to disable runtime detection.",
+    window.showWarningMessage("Check Terminal view for an erroring 'detect node runtime' session. Capture details for investigation, then kill the terminal to continue SQLTools extension startup. Change the 'sqltools.useNodeRuntime' setting to disable runtime detection.",
       { modal: true });
       commands.executeCommand("terminal.focus");
   }, 5000);


### PR DESCRIPTION
This fixes a minor nit noticed on #1037.

![image](https://user-images.githubusercontent.com/6726799/202412898-7948c9d1-f1d9-4792-a968-ec63b964beff.png)

Should say `sqltools.useNodeRuntime`.
