### PR TITLE
Let drivers implement a `resolveConnection` function

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -2,7 +2,7 @@
     "name": "sqltools",
     "displayName": "SQLTools",
     "description": "Connecting users to many of the most commonly used databases. Welcome to database management done right.",
-    "version": "0.26.0",
+    "version": "0.27.0-SNAPSHOT",
     "publisher": "mtxr",
     "license": "MIT",
     "preview": false,

--- a/packages/plugins/connection-manager/explorer/index.ts
+++ b/packages/plugins/connection-manager/explorer/index.ts
@@ -9,6 +9,7 @@ import sortBy from 'lodash/sortBy';
 import { createLogger } from '@sqltools/log/src';
 import Context from '@sqltools/vscode/context';
 import Config from '@sqltools/util/config-manager';
+import { resolveConnection } from '../extension-util';
 
 const log = createLogger('conn-man:explorer');
 
@@ -40,8 +41,10 @@ export class ConnectionExplorer implements TreeDataProvider<SidebarTreeItem> {
 
   public async getActive(): Promise<IConnection | null> {
     const conns = await this.getConnections();
-    const active = conns.find(c => c.isActive);
+    let active = conns.find(c => c.isActive);
     if (!active) return null;
+
+    active = await resolveConnection(active);
 
     return {
       ...active,
@@ -78,7 +81,11 @@ export class ConnectionExplorer implements TreeDataProvider<SidebarTreeItem> {
   public async getConnectionById(id: string): Promise<IConnection> {
     if (!id) return null;
     const items = await this.getConnections();
-    return items.find(c => getConnectionId(c) === id) || null;
+    let connection = items.find(c => getConnectionId(c) === id) || null;
+    if (connection) {
+      connection = await resolveConnection(connection);
+    }
+    return connection;
   }
 
   public getSelection() {

--- a/packages/plugins/connection-manager/extension-util.ts
+++ b/packages/plugins/connection-manager/extension-util.ts
@@ -1,7 +1,7 @@
 import { extensions } from 'vscode';
 import Context from '@sqltools/vscode/context';
 import PluginResourcesMap, { buildResourceKey } from '@sqltools/util/plugin-resources';
-import { IDriverExtensionApi, IIcons } from '@sqltools/types';
+import { IConnection, IDriverExtensionApi, IIcons } from '@sqltools/types';
 import fs from 'fs';
 import prepareSchema from './webview/lib/prepare-schema';
 import { SettingsScreenState } from './webview/ui/screens/Settings/interfaces';
@@ -83,3 +83,11 @@ export const driverPluginExtension = async (driverName: string) => {
   if (!pluginExtenxionId) return null;
   return getExtension(pluginExtenxionId);
 };
+
+export const resolveConnection = async (connInfo: IConnection) => {
+  const pluginExt = await driverPluginExtension(connInfo.driver);
+  if (pluginExt && pluginExt.resolveConnection) {
+    connInfo = await pluginExt.resolveConnection({ connInfo });
+  }
+  return connInfo;
+}

--- a/packages/plugins/connection-manager/extension-util.ts
+++ b/packages/plugins/connection-manager/extension-util.ts
@@ -78,10 +78,10 @@ export const getExtension = async (id: string): Promise<IDriverExtensionApi | nu
 };
 
 export const driverPluginExtension = async (driverName: string) => {
-  const pluginExtenxionId = PluginResourcesMap.get(buildResourceKey({ type: 'driver', name: driverName, resource: 'extension-id' }));
-  log.debug(`Driver name %s. Plugin ext: %s`, driverName, pluginExtenxionId);
-  if (!pluginExtenxionId) return null;
-  return getExtension(pluginExtenxionId);
+  const pluginExtensionId = PluginResourcesMap.get(buildResourceKey({ type: 'driver', name: driverName, resource: 'extension-id' }));
+  log.debug(`Driver name %s. Plugin ext: %s`, driverName, pluginExtensionId);
+  if (!pluginExtensionId) return null;
+  return getExtension(pluginExtensionId);
 };
 
 export const resolveConnection = async (connInfo: IConnection) => {

--- a/packages/plugins/connection-manager/extension.ts
+++ b/packages/plugins/connection-manager/extension.ts
@@ -22,7 +22,7 @@ import { CancellationTokenSource, commands, ConfigurationTarget, env as vscodeEn
 import CodeLensPlugin from '../codelens/extension';
 import { ConnectRequest, DisconnectRequest, ForceListRefresh, GetChildrenForTreeItemRequest, GetConnectionPasswordRequest, GetConnectionsRequest, GetInsertQueryRequest, ProgressNotificationComplete, ProgressNotificationCompleteParams, ProgressNotificationStart, ProgressNotificationStartParams, ReleaseResultsRequest, RunCommandRequest, GetResultsRequest, SearchConnectionItemsRequest, TestConnectionRequest } from './contracts';
 import DependencyManager from './dependency-manager/extension';
-import { getExtension } from './extension-util';
+import { getExtension, resolveConnection } from './extension-util';
 import statusBar from './status-bar';
 import { removeAttachedConnection, attachConnection, getAttachedConnection } from './attached-files';
 
@@ -51,6 +51,7 @@ export class ConnectionManagerPlugin implements IExtensionPlugin {
 
   private ext_testConnection = async (c: IConnection) => {
     let password = null;
+    c = await resolveConnection(c);
 
     if (c.askForPassword) password = await this._askForPassword(c);
     if (c.askForPassword && password === null) return;
@@ -576,6 +577,7 @@ export class ConnectionManagerPlugin implements IExtensionPlugin {
     let password = null;
 
     if (c) {
+      c = await resolveConnection(c);
       c.id = getConnectionId(c);
     }
 

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -729,7 +729,8 @@ export interface IExtension {
 
 export interface IDriverExtensionApi {
   /**
-   * Prepare connection settings that will be saved to settings file
+   * Prepare connection settings that will be saved to settings file,
+   * and/or resolve settings before passing them to the language server (e.g. call an AuthenticationProvider to retrieve credentials)
    *
    * @param {{ connInfo: IConnection }} arg
    * @returns {(Promise<IConnection> | IConnection)}
@@ -737,6 +738,7 @@ export interface IDriverExtensionApi {
    */
   parseBeforeSaveConnection?(arg: { connInfo: IConnection }): Promise<IConnection> | IConnection;
   parseBeforeEditConnection?(arg: { connInfo: IConnection }): Promise<IConnection> | IConnection;
+  resolveConnection?(arg: { connInfo: IConnection }): Promise<IConnection> | IConnection;
   readonly driverName?: string;
   readonly driverAliases: IDriverAlias[];
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sqltools/types",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "SQLTools interfaces and types",
   "types": "index.d.ts",
   "main": "index.js",


### PR DESCRIPTION
This PR enhances the interface between this extension and its drivers, allowing a driver to specify a callback function that will be invoked after this extension retrieves connection information from user/workspace settings but before those settings are sent to the language server part of the driver.

Use-cases include drivers that want to look up credentials from secure storage before sending them to the target server.
