### PR TITLE
Add a connection count badge

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "type": "git"
   },
   "engines": {
-    "vscode": "^1.42.0",
+    "vscode": "^1.72.0",
     "node": ">=10"
   },
   "private": true,

--- a/packages/driver.mssql/package.json
+++ b/packages/driver.mssql/package.json
@@ -4,7 +4,7 @@
   "description": "SQLTools Microsoft SQL Server/Azure",
   "version": "0.3.0",
   "engines": {
-    "vscode": "^1.42.0"
+    "vscode": "^1.72.0"
   },
   "publisher": "mtxr",
   "license": "MIT",
@@ -68,7 +68,7 @@
     "@sqltools/base-driver": "latest",
     "@types/lodash": "^4.14.123",
     "@types/mssql": "^4.0.12",
-    "@types/vscode": "^1.42.0",
+    "@types/vscode": "^1.72.0",
     "concurrently": "^5.2.0",
     "esbuild": "^0.15.7",
     "lodash": "^4.17.19",

--- a/packages/driver.mysql/package.json
+++ b/packages/driver.mysql/package.json
@@ -4,7 +4,7 @@
   "description": "SQLTools MySQL/MariaDB",
   "version": "0.4.1",
   "engines": {
-    "vscode": "^1.42.0"
+    "vscode": "^1.72.0"
   },
   "publisher": "mtxr",
   "license": "MIT",
@@ -69,7 +69,7 @@
     "@sqltools/types": "^0.1.6",
     "@types/lodash": "^4.14.123",
     "@types/mysql": "^2.15.12",
-    "@types/vscode": "^1.42.0",
+    "@types/vscode": "^1.72.0",
     "compare-versions": "3.6.0",
     "concurrently": "^5.2.0",
     "esbuild": "^0.15.7",

--- a/packages/driver.pg/package.json
+++ b/packages/driver.pg/package.json
@@ -4,7 +4,7 @@
   "description": "SQLTools PostgreSQL/Cockroach Driver",
   "version": "0.4.0",
   "engines": {
-    "vscode": "^1.42.0"
+    "vscode": "^1.72.0"
   },
   "publisher": "mtxr",
   "license": "MIT",
@@ -70,7 +70,7 @@
     "@sqltools/base-driver": "latest",
     "@types/lodash": "^4.14.123",
     "@types/pg": "^7.14.3",
-    "@types/vscode": "^1.42.0",
+    "@types/vscode": "^1.72.0",
     "concurrently": "^5.2.0",
     "esbuild": "^0.15.7",
     "lodash": "^4.17.19",

--- a/packages/driver.sqlite/package.json
+++ b/packages/driver.sqlite/package.json
@@ -4,7 +4,7 @@
   "description": "SQLTools SQLite",
   "version": "0.4.1",
   "engines": {
-    "vscode": "^1.42.0"
+    "vscode": "^1.72.0"
   },
   "publisher": "mtxr",
   "license": "MIT",
@@ -65,7 +65,7 @@
   "devDependencies": {
     "@sqltools/base-driver": "^0.1.11",
     "@types/sqlite3": "^3.1.8",
-    "@types/vscode": "^1.42.0",
+    "@types/vscode": "^1.72.0",
     "concurrently": "^5.2.0",
     "cross-env": "^7.0.2",
     "esbuild": "^0.15.7",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -18,7 +18,7 @@
     "author": "Matheus Teixeira <me@mteixeira.dev>",
     "private": true,
     "engines": {
-        "vscode": "^1.42.0"
+        "vscode": "^1.72.0"
     },
     "categories": [
         "Programming Languages",
@@ -1211,7 +1211,7 @@
         "@types/command-exists": "^1.2.0",
         "@types/jest": "^24.0.11",
         "@types/lodash": "^4.14.123",
-        "@types/vscode": "^1.42.0",
+        "@types/vscode": "^1.72.0",
         "cross-env": "^7.0.2",
         "jest": "^26.6.3",
         "jest-cli": "^26.6.3",

--- a/packages/log/package.json
+++ b/packages/log/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@types/pino": "^6.3.0",
-    "@types/vscode": "^1.47.0",
+    "@types/vscode": "^1.72.0",
     "rimraf": "^3.0.0",
     "typescript": "~4.8.3"
   }

--- a/packages/plugins/bookmarks-manager/extension.ts
+++ b/packages/plugins/bookmarks-manager/extension.ts
@@ -18,7 +18,7 @@ export default class BookmarksManagerPlugin implements IExtensionPlugin {
         Object.values(group.items).map<QuickPickItem>(item => ({
           label: item.name,
           detail: typeof item.description === 'string' ? item.description : undefined,
-          description: group.label,
+          description: typeof group.label === 'string' ? group.label : group.label?.label,
           item,
         }))
       ), []);

--- a/packages/plugins/connection-manager/explorer/SidebarAbstractItem.ts
+++ b/packages/plugins/connection-manager/explorer/SidebarAbstractItem.ts
@@ -12,7 +12,7 @@ export default abstract class SidebarAbstractItem<T extends SidebarItemIterface<
   protected _snippet: SnippetString;
   get snippet() {
     if (!this._snippet) {
-      this._snippet = new SnippetString(this.label);
+      this._snippet = new SnippetString(typeof this.label === 'string' ? this.label : this.label?.label);
     }
     return this._snippet;
   };

--- a/packages/plugins/connection-manager/explorer/SidebarItem.ts
+++ b/packages/plugins/connection-manager/explorer/SidebarItem.ts
@@ -1,4 +1,4 @@
-import { ThemeIcon, TreeItemCollapsibleState, commands, TreeItem } from 'vscode';
+import { ThemeIcon, TreeItemCollapsibleState, commands, TreeItem, Uri } from 'vscode';
 import SidebarAbstractItem from './SidebarAbstractItem';
 import { getIconPaths } from '@sqltools/vscode/icons';
 import { MConnectionExplorer, ContextValue } from '@sqltools/types';
@@ -6,7 +6,7 @@ import { EXT_NAMESPACE } from '@sqltools/util/constants';
 import { SidebarConnection } from '.';
 
 export default class SidebarItem<T extends MConnectionExplorer.IChildItem = MConnectionExplorer.IChildItem> extends SidebarAbstractItem<SidebarItem> {
-  public iconPath = ThemeIcon.Folder;
+  public iconPath: ThemeIcon | { light: Uri, dark: Uri} = ThemeIcon.Folder;
   public value: string;
   public async getChildren() {
     const items: MConnectionExplorer.IChildItem[] = await commands.executeCommand(`${EXT_NAMESPACE}.getChildrenForTreeItem`, {
@@ -25,7 +25,7 @@ export default class SidebarItem<T extends MConnectionExplorer.IChildItem = MCon
     super(metadata.label, TreeItemCollapsibleState.Collapsed);
     this.conn = this.parent.conn;
     this.description = this.metadata ? this.metadata.detail || null : null;
-    this.value = this.label;
+    this.value = typeof this.label === 'string' ? this.label : this.label?.label;
     metadata.snippet && (this.snippet = metadata.snippet);
     if (metadata.type) {
       this.contextValue = metadata.type;

--- a/packages/plugins/connection-manager/explorer/index.ts
+++ b/packages/plugins/connection-manager/explorer/index.ts
@@ -131,7 +131,8 @@ export class ConnectionExplorer implements TreeDataProvider<SidebarTreeItem> {
       return null;
     }
 
-    let active = null;
+    let connectedTreeCount = 0;
+    let active: IConnection<any>;
     if (groupConnected) {
       return this.getGroupedRootItems(items);
     }
@@ -141,6 +142,9 @@ export class ConnectionExplorer implements TreeDataProvider<SidebarTreeItem> {
     items.forEach(item => {
       if (item.isActive) {
         active = item.conn;
+      }
+      if (item.isConnected) {
+        connectedTreeCount++;
       }
       let currentGroup: ConnectionGroup = root;
       if (item.conn && item.conn.group) {
@@ -152,6 +156,12 @@ export class ConnectionExplorer implements TreeDataProvider<SidebarTreeItem> {
     });
     this._onDidChangeActiveConnection.fire(active);
 
+    if (connectedTreeCount > 0) {
+      this.treeView.badge = { value: connectedTreeCount, tooltip: active ? `Connection '${active.name}' is active` : 'No connection is active'};
+    } else {
+      this.treeView.badge = undefined;
+    }
+
     root.items = sortBy(root.items, ['isGroup', 'label']);
 
     return root.items;
@@ -162,7 +172,7 @@ export class ConnectionExplorer implements TreeDataProvider<SidebarTreeItem> {
     notConnectedTreeItem.items = [];
     let connectedTreeCount = 0;
     let notConnectedTreeCount = 0;
-    let active = null;
+    let active: IConnection<any>;
     items.forEach(item => {
       if (item.isActive) {
         active = item.conn;
@@ -183,6 +193,12 @@ export class ConnectionExplorer implements TreeDataProvider<SidebarTreeItem> {
       currentGroup.items.push(item);
     });
     this._onDidChangeActiveConnection.fire(active);
+
+    if (connectedTreeCount > 0) {
+      this.treeView.badge = { value: connectedTreeCount, tooltip: active ? `Connection '${active.name}' is active` : 'No connection is active'};
+    } else {
+      this.treeView.badge = undefined;
+    }
 
     connectedTreeItem.items = sortBy(connectedTreeItem.items, ['isGroup', 'label']);
     notConnectedTreeItem.items = sortBy(notConnectedTreeItem.items, ['isGroup', 'label']);

--- a/packages/plugins/history-manager/extension.ts
+++ b/packages/plugins/history-manager/extension.ts
@@ -30,7 +30,7 @@ export default class ConnectionManagerPlugin implements IExtensionPlugin {
         group.items.map<QuickPickItem>(item => ({
           label: item.query,
           detail: typeof item.description === "string" ? item.description : "",
-          description: group.label,
+          description: typeof group.label === 'string' ? group.label : group.label?.label,
         }))
       ), []);
     return await quickPick(

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -16,7 +16,7 @@
     "uuid": "^8.1.0"
   },
   "devDependencies": {
-    "@types/vscode": "^1.42.0",
+    "@types/vscode": "^1.72.0",
     "jest": "^26.6.3",
     "jest-cli": "^26.6.3",
     "ts-jest": "^26.5.4",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -8,7 +8,7 @@
   "private": true,
   "devDependencies": {
     "@types/jest": "^24.0.11",
-    "@types/vscode": "^1.42.0",
+    "@types/vscode": "^1.72.0",
     "jest": "^26.6.3",
     "jest-cli": "^26.6.3",
     "ts-jest": "^26.5.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1908,10 +1908,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/vscode@^1.42.0", "@types/vscode@^1.47.0":
-  version "1.48.0"
-  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.48.0.tgz#c1841ccf80086d53b35a9d7f2eb3b4d949bd2d2f"
-  integrity sha512-sZJKzsJz1gSoFXcOJWw3fnKl2sseUgZmvB4AJZS+Fea+bC/jfGPVhmFL/FfQHld/TKtukVONsmoD3Pkyx9iadg==
+"@types/vscode@^1.72.0":
+  version "1.74.0"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.74.0.tgz#4adc21b4e7f527b893de3418c21a91f1e503bdcd"
+  integrity sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==
 
 "@types/webpack-env@^1.15.2":
   version "1.15.2"


### PR DESCRIPTION
This implements #994, adding a connection count badge to the activity bar icon. The badge also has a tooltip showing the name of the active connection.

The badge API arrived in VS Code 1.72, so this is now the minimum version we require.
