### PR TITLE
Support for Interpolated Variables from Connections Config

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -544,7 +544,7 @@
                 },
                 "sqltools.queryParams.regex": {
                     "type": "string",
-                    "default": "\\$[\\d]+|\\$\\[[\\d\\w]+\\]",
+                    "default": "\\$[\\d]+|\\$\\[([\\d\\w]+)\\]",
                     "description": "RegEx used to identify query parameters.",
                     "required": true
                 },
@@ -721,6 +721,15 @@
                                         "default": null
                                     }
                                 }
+                            },
+                            "variables": {
+                                "type": [
+                                    "object",
+                                    "null"
+                                ],
+                                "default": null,
+                                "description": "Connection variables in a key/value pair format, this property needs to be used with `sqltools.queryParams.enableReplace` to replace the variables without prompting.",
+                                "properties": {}
                             }
                         }
                     }

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -728,7 +728,7 @@
                                     "null"
                                 ],
                                 "default": null,
-                                "description": "Connection variables in a key/value pair format, this property needs to be used with `sqltools.queryParams.enableReplace` to replace the variables without prompting.",
+                                "description": "Connection variables in a key/value pair format. Use this property with `sqltools.queryParams.enableReplace` to replace the variables without prompting.",
                                 "properties": {}
                             }
                         }

--- a/packages/plugins/connection-manager/extension.ts
+++ b/packages/plugins/connection-manager/extension.ts
@@ -276,10 +276,9 @@ export class ConnectionManagerPlugin implements IExtensionPlugin {
         await this._connect();
       }
 
-      this._askForPassword
-
       const conn = await this.explorer.getActive()
       query = await this.replaceParams(query, conn);
+      
       const view = await this._openResultsWebview(conn && conn.id, opt.requestId);
       const payload = await this._runConnectionCommandWithArgs('query', query, { ...opt, requestId: view.requestId });
       this.updateViewResults(view, payload);

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -191,8 +191,14 @@ export interface IConnection<DriverOptions = any> {
     connected?: string;
     disconnected?: string;
   };
-
-
+  /**
+   * Connection variables, this property needs to be used with `sqltools.queryParams.enableReplace` to replace the variables without prompting.
+   * @type {object}
+   * @memberof IConnection
+   */
+  variables?: {
+    [key: string]: string
+  }
 
   // WONT BE INCLUDED IN SETTINGS
   /**

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -192,7 +192,7 @@ export interface IConnection<DriverOptions = any> {
     disconnected?: string;
   };
   /**
-   * Connection variables, this property needs to be used with `sqltools.queryParams.enableReplace` to replace the variables without prompting.
+   * Connection variables. Use this property with `sqltools.queryParams.enableReplace` to replace the variables without prompting.
    * @type {object}
    * @memberof IConnection
    */

--- a/packages/util/query/index.ts
+++ b/packages/util/query/index.ts
@@ -60,7 +60,7 @@ export function getQueryParameters(query: string, regexStr: string) {
 
   const regex = new RegExp(regexStr, 'g');
 
-  const paramsMap: { [k: string]: { param: string; string: string; }} = {};
+  const paramsMap: { [k: string]: { param: string; string: string; varName?: string }} = {};
 
   let match;
   while ((match = regex.exec(query)) !== null) {
@@ -70,6 +70,10 @@ export function getQueryParameters(query: string, regexStr: string) {
         param: match[0],
         string: `...${queryPart}...`,
       };
+
+      if (match[1]) {
+        paramsMap[match[0]].varName = match[1]
+      }
     }
   }
   return Object.values(paramsMap);

--- a/test/docker/sqlite/1.create-some-stuff.sql
+++ b/test/docker/sqlite/1.create-some-stuff.sql
@@ -17,7 +17,7 @@ CREATE TABLE contacts_metadata (
   FOREIGN KEY(contact_id) REFERENCES contact(id)
 );
 
-CREATE VIEW contacts_view
+CREATE VIEW contacts_view_$[env]
 AS
 SELECT
 *

--- a/test/test-vscode-sqltools.code-workspace
+++ b/test/test-vscode-sqltools.code-workspace
@@ -75,7 +75,10 @@
         "name": "SQLite",
         "driver": "SQLite",
         "database": "./docker/sqlite/test_db.db",
-        "connectionTimeout": 15
+        "connectionTimeout": 15,
+        "variables": {
+          "env": "dev"
+        }
       },
       {
         "askForPassword": false,


### PR DESCRIPTION
This PR adds support for interpolated variables from the connection config.

Example:

```json
{
  "sqltools.queryParams.enableReplace": true,
  "sqltools.connections": [
    {
      "name": "SQLite",
      "driver": "SQLite",
      "database": "./docker/sqlite/test_db.db",
      "connectionTimeout": 15,
      "variables": {
        "env": "dev"
      }
    }
  ]
}
```

Query:

```sql
SELECT * FROM table_$[env];
```

You can also use Jinja format by adding the `sqltools.queryParams.regex` property with this value `\\{\\{(.*)\\}\\}`

Query:

```sql
SELECT * FROM table_{{ env }};
```

#### Benefits

Using pre-defined variables from the connection config to avoid prompting the variable value every time the user runs the query.

#### Related Issues

- #744

----

Thank you for your contribution! 
Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] You have made the needed changes to the docs
- [x] You have written a description of what is the purpose of this pull request above
