### PR TITLE
Fix errors when re-using tabs with different cols

### DIFF
--- a/packages/plugins/connection-manager/webview/ui/screens/Results/components/Table/computeColumnWidths.tsx
+++ b/packages/plugins/connection-manager/webview/ui/screens/Results/components/Table/computeColumnWidths.tsx
@@ -1,0 +1,11 @@
+import get from 'lodash/get';
+import _ from 'lodash';
+const computeColumnWidths = (colNames: string[], rows: object[]) => {
+  const firstRows = rows.slice(0, 5);
+  const values = colNames.map(columnName => {
+    const maxCharacters = Math.max(...firstRows.map(row => JSON.stringify(get(row, [columnName], '')).length - 2));
+    return Math.min(Math.max(20, maxCharacters) * 7.5, 600);
+  });
+  return _.zipObject(colNames, values);
+}
+export default computeColumnWidths;

--- a/packages/plugins/connection-manager/webview/ui/screens/Results/components/Table/generateColumnExtensions.tsx
+++ b/packages/plugins/connection-manager/webview/ui/screens/Results/components/Table/generateColumnExtensions.tsx
@@ -1,8 +1,0 @@
-import { filterPredicate } from '../../lib/filterPredicate';
-import get from 'lodash/get';
-const generateColumnExtensions = (colNames, rows) => colNames.map(columnName => ({
-  columnName,
-  predicate: filterPredicate,
-  width: Math.min(Math.max(20, JSON.stringify(get(rows, [0, columnName], '')).length - 2, JSON.stringify(get(rows, [1, columnName], '')).length - 2, JSON.stringify(get(rows, [2, columnName], '')).length - 2, JSON.stringify(get(rows, [3, columnName], '')).length - 2, JSON.stringify(get(rows, [4, columnName], '')).length - 2) * 7.5, 600)
-}));
-export default generateColumnExtensions;


### PR DESCRIPTION
As described in #1073, tab reuse didn't work when the columns of the result changed. I've fixed this now so that no more errors are displayed. The issue was rooted in the fact that the new column widths were computed only after rendering, such that some columns were lacking a width.

Sizes of columns that have been manually resized are kept, even if the query changes.

Closes #1073.

----

Thank you for your contribution! 
Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
  - Honestly, I have no idea whether this is the case. I barely managed to get a setup working at all, which took >1.5h. Would need additional instructions to check this (if it isn't done automatically in a pipeline). Since the changes are small and I didn't see anything in the IDE, I would assume that it is the case. **EDIT:** I ran the pipeline in my own fork and it's looking good.
- [x] You have made the needed changes to the docs
  - Since this is a bugfix, no changes are required
- [x] You have written a description of what is the purpose of this pull request above
