### PR TITLE
Bump version strings for main, mysql and pg extensions

### DIFF
--- a/packages/driver.mssql/package.json
+++ b/packages/driver.mssql/package.json
@@ -2,7 +2,7 @@
   "name": "sqltools-driver-mssql",
   "displayName": "SQLTools Microsoft SQL Server/Azure",
   "description": "SQLTools Microsoft SQL Server/Azure",
-  "version": "0.4.0",
+  "version": "0.4.1-SNAPSHOT",
   "engines": {
     "vscode": "^1.72.0"
   },

--- a/packages/driver.mysql/package.json
+++ b/packages/driver.mysql/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@mysql/xdevapi": "^8.0.20",
     "@sqltools/base-driver": "latest",
-    "@sqltools/types": "^0.1.6",
+    "@sqltools/types": "^0.1.7",
     "@types/lodash": "^4.14.123",
     "@types/mysql": "^2.15.12",
     "@types/vscode": "^1.72.0",

--- a/packages/driver.mysql/package.json
+++ b/packages/driver.mysql/package.json
@@ -2,7 +2,7 @@
   "name": "sqltools-driver-mysql",
   "displayName": "SQLTools MySQL/MariaDB",
   "description": "SQLTools MySQL/MariaDB",
-  "version": "0.5.0",
+  "version": "0.5.1-SNAPSHOT",
   "engines": {
     "vscode": "^1.72.0"
   },

--- a/packages/driver.pg/package.json
+++ b/packages/driver.pg/package.json
@@ -2,7 +2,7 @@
   "name": "sqltools-driver-pg",
   "displayName": "SQLTools PostgreSQL/Cockroach Driver",
   "description": "SQLTools PostgreSQL/Cockroach Driver",
-  "version": "0.5.0",
+  "version": "0.5.1-SNAPSHOT",
   "engines": {
     "vscode": "^1.72.0"
   },

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -2,7 +2,7 @@
     "name": "sqltools",
     "displayName": "SQLTools",
     "description": "Connecting users to many of the most commonly used databases. Welcome to database management done right.",
-    "version": "0.27.0",
+    "version": "0.27.1-SNAPSHOT",
     "publisher": "mtxr",
     "license": "MIT",
     "preview": false,


### PR DESCRIPTION
Also update mysql driver's dependency on @sqltools/types now that 0.1.7 has been published.