### PR TITLE
fix: unnecessary password prompt on mysql driver connection strings

### DIFF
--- a/packages/driver.mysql/src/extension.ts
+++ b/packages/driver.mysql/src/extension.ts
@@ -90,7 +90,7 @@ export async function activate(extContext: vscode.ExtensionContext): Promise<IDr
        * This hook is called after a connection definition has been fetched
        * from settings and is about to be used to connect.
        */
-      if (connInfo.password === undefined && !connInfo.askForPassword) {
+      if (connInfo.password === undefined && !connInfo.askForPassword && !connInfo.connectString) {
         const scopes = [connInfo.name, (connInfo.username || "")];
         let session = await vscode.authentication.getSession(
           AUTHENTICATION_PROVIDER,


### PR DESCRIPTION
Describe here what is this PR about and what we are achieving merging this.
----
the extension was prompting for Driver Credentials even when connecting with connection strings

----

Thank you for your contribution! 
Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] You have made the needed changes to the docs
- [x] You have written a description of what is the purpose of this pull request above
