### PR TITLE
Auto publish extensions after tag/release

### DIFF
--- a/.github/workflows/upload-release-assets.yml
+++ b/.github/workflows/upload-release-assets.yml
@@ -45,3 +45,15 @@ jobs:
         args: "*.vsix"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Upload to VSCode Marketplace and Open-VSX
+      env:
+        OVSX_TOKEN: ${{ secrets.OVSX_TOKEN }}
+        VSCE_PAT: ${{ secrets.VSCE_PAT }}
+      run: |
+        for FILE in *.vsix; do
+          echo "Publishing $FILE"
+          npx vsce publish --packagePath $FILE
+          npx ovsx publish $FILE -p $OVSX_TOKEN
+          echo "Published $FILE"
+        done


### PR DESCRIPTION
This PR adds the ability to auto publish extensions to Both VS Code Marketplace and Open VSX/Eclipse Foundation registry.

I wasn't able to test this in the repository here, but I tested with an example extension and this code should work as is, though if any chages are required while releasing, don't hesitate to reach out to me.

----

Thank you for your contribution! 
Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] You have made the needed changes to the docs
- [x] You have written a description of what is the purpose of this pull request above
