### PR TITLE
Fix broken links on 'contributing' page

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -14,4 +14,7 @@ export default defineConfig({
     sitemap(),
   ],
   site: `https://vscode-sqltools.mteixeira.dev`,
+  build: {
+    format: 'file'
+  }
 });


### PR DESCRIPTION
Docs page at https://vscode-sqltools.mteixeira.dev/en/contributing/ had broken links to 'building' and 'testing' pages.

This PR tries to fix the issue by changing the [`build.format`](https://docs.astro.build/en/reference/configuration-reference/#buildformat) setting so that it generates `contributing.html` at the site root rather than the file `contributing/index.html`

