### PR TITLE
Eliminate log warning about use of deprecated `new Buffer()`

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -2,7 +2,7 @@
     "name": "sqltools",
     "displayName": "SQLTools",
     "description": "Connecting users to many of the most commonly used databases. Welcome to database management done right.",
-    "version": "0.27.1",
+    "version": "0.27.2-SNAPSHOT",
     "publisher": "mtxr",
     "license": "MIT",
     "preview": false,

--- a/packages/extension/test/__mocks__/fs.ts
+++ b/packages/extension/test/__mocks__/fs.ts
@@ -23,7 +23,7 @@ function existsSync(directoryPath) {
 }
 
 function writeFileSync(directoryPath, content) {
-  mockFiles[directoryPath] = new Buffer(content);
+  mockFiles[directoryPath] = Buffer.from(content);
 }
 
 fs.readFileSync = readFileSync;

--- a/packages/util/persistence/serializable-storage.ts
+++ b/packages/util/persistence/serializable-storage.ts
@@ -15,7 +15,7 @@ export default class SerializableStorage<Item, Key = string | number | Symbol> {
 
   public read(): this {
     try {
-      const content = fs.readFileSync(this.storagePath, { encoding: this.encoding });
+      const content = fs.readFileSync(this.storagePath, this.encoding);
       if (content && content.length > 0) {
         this.items = JSON.parse(content);
       } else {
@@ -27,16 +27,11 @@ export default class SerializableStorage<Item, Key = string | number | Symbol> {
     return this;
   }
 
-  private serializeContent(): Buffer {
-    return new Buffer(JSON.stringify(this.items, null, 2), 'utf8');
-  }
   public save(): this {
-    return this.write();
-  }
-  private write(): this {
-    fs.writeFileSync(this.storagePath, this.serializeContent());
+    fs.writeFileSync(this.storagePath, JSON.stringify(this.items, null, 2), this.encoding);
     return this;
   }
+
   public reset(): this {
     this.items = JSON.parse(this.defaultSerializable);
     return this;


### PR DESCRIPTION
This PR fixes #1133.