### PR TITLE
Implement drag and drop objects

### DIFF
--- a/packages/extension/src/index.ts
+++ b/packages/extension/src/index.ts
@@ -18,6 +18,7 @@ const log = createLogger();
 
 // plugins
 import ConnectionManagerPlugin from '@sqltools/plugins/connection-manager/extension';
+import ObjectDropProviderPlugin from '@sqltools/plugins/objectdrop-provider/extension';
 import HistoryManagerPlugin from '@sqltools/plugins/history-manager/extension';
 import BookmarksManagerPlugin from '@sqltools/plugins/bookmarks-manager/extension';
 import FormatterPlugin from '@sqltools/plugins/formatter/extension';
@@ -306,7 +307,8 @@ export function activate(ctx: ExtensionContext) {
       ConnectionManagerPlugin,
       new HistoryManagerPlugin,
       new BookmarksManagerPlugin,
-      new AuthenticationProviderPlugin
+      new AuthenticationProviderPlugin,
+      new ObjectDropProviderPlugin,
     ])
     return instance.activate();
 

--- a/packages/plugins/connection-manager/explorer/index.ts
+++ b/packages/plugins/connection-manager/explorer/index.ts
@@ -220,14 +220,14 @@ export class ConnectionExplorer implements TreeDataProvider<SidebarTreeItem>, Tr
     return this.messagesTreeViewProvider.addMessages;
   }
   //#region Drag and drop definitions
-  dropMimeTypes: readonly string[] = ['application/vnd.code.tree.sqltoolsobjectdrop', 'text/uri-list'];
-  dragMimeTypes: readonly string[] = ['application/vnd.code.tree.sqltoolsobjectdrop'];
+  dropMimeTypes: readonly string[] = ['application/vnd.code.tree.connectionExplorer','text/uri-list'];
+  dragMimeTypes: readonly string[] = ['application/vnd.code.tree.connectionExplorer'];
   handleDrag(
     source: readonly SidebarTreeItem[]
     , dataTransfer: DataTransfer
     , _token: CancellationToken
   ): void | Thenable<void> {
-    dataTransfer.set('application/vnd.code.tree.sqltoolsobjectdrop', new DataTransferItem(JSON.stringify(source)));
+    dataTransfer.set('application/vnd.code.tree.connectionExplorer', new DataTransferItem(JSON.stringify(source)));
     console.log(`Dragging item ${JSON.stringify(source)}`);
   }
   //#endregion Drag and drop definitions

--- a/packages/plugins/connection-manager/explorer/index.ts
+++ b/packages/plugins/connection-manager/explorer/index.ts
@@ -228,7 +228,6 @@ export class ConnectionExplorer implements TreeDataProvider<SidebarTreeItem>, Tr
     , _token: CancellationToken
   ): void | Thenable<void> {
     dataTransfer.set('application/vnd.code.tree.connectionExplorer', new DataTransferItem(JSON.stringify(source)));
-    console.log(`Dragging item ${JSON.stringify(source)}`);
   }
   //#endregion Drag and drop definitions
 }

--- a/packages/plugins/objectdrop-provider/extension.ts
+++ b/packages/plugins/objectdrop-provider/extension.ts
@@ -1,7 +1,6 @@
 import { languages, DocumentSelector, CancellationToken, DataTransfer, DocumentDropEdit, DocumentDropEditProvider, Position, TextDocument } from "vscode";
 import { IExtensionPlugin, IExtension } from '@sqltools/types';
 import Context from '@sqltools/vscode/context';
-import { Print } from "@material-ui/icons";
 
 class ObjectDropProvider implements DocumentDropEditProvider {
     async provideDocumentDropEdits(
@@ -11,7 +10,7 @@ class ObjectDropProvider implements DocumentDropEditProvider {
         , _token: CancellationToken
     ): Promise<DocumentDropEdit | undefined> {
         console.log("Editor item drop detected");
-        const dataTransferItem = dataTransfer.get('application/vnd.code.tree.sqltoolsobjectdrop');
+        const dataTransferItem = await dataTransfer.get('application/vnd.code.tree.connectionExplorer');
         if (!dataTransferItem) {
             console.log("No data transfer items found, canceling");
             return undefined;

--- a/packages/plugins/objectdrop-provider/extension.ts
+++ b/packages/plugins/objectdrop-provider/extension.ts
@@ -1,0 +1,65 @@
+import { languages, DocumentSelector, CancellationToken, DataTransfer, DocumentDropEdit, DocumentDropEditProvider, Position, TextDocument } from "vscode";
+import { IExtensionPlugin, IExtension } from '@sqltools/types';
+import Context from '@sqltools/vscode/context';
+import { Print } from "@material-ui/icons";
+
+class ObjectDropProvider implements DocumentDropEditProvider {
+    async provideDocumentDropEdits(
+        _document: TextDocument
+        , _position: Position
+        , dataTransfer: DataTransfer
+        , _token: CancellationToken
+    ): Promise<DocumentDropEdit | undefined> {
+        console.log("Editor item drop detected");
+        const dataTransferItem = dataTransfer.get('application/vnd.code.tree.sqltoolsobjectdrop');
+        if (!dataTransferItem) {
+            console.log("No data transfer items found, canceling");
+            return undefined;
+        }
+        dataTransfer.forEach((item, mimetype) => {
+            console.log("Itterate types");
+            console.log(`${mimetype} - ${JSON.stringify(item)}`);
+        });
+
+        const val = await dataTransferItem.value;
+        console.log(`Recieved data ${JSON.stringify(dataTransferItem)}, ${JSON.stringify(val)}`);
+        const snippet: DocumentDropEdit = new DocumentDropEdit(val);
+        console.log(`Dropped data ${JSON.stringify(snippet)}`);
+        return snippet;
+    }
+}
+
+export default class ObjectDropProviderPlugin implements IExtensionPlugin {
+    public type: "driver" | "plugin" = "plugin";
+    public name: string = "Object Drop-in Provider";
+    private isRegistered: boolean = false;
+
+    register(_extension: IExtension) {
+        console.log("Checking whether to register object drop extension");
+        if (this.isRegistered) {
+            return; // do not register twice
+        }
+        console.log("Registering object drop provider");
+
+        // Register editor drop-in plugin which will allow dropping data from the connection explorer
+
+        // Register unsaved files (included .session files generated when connecting to a source via sqltools)
+        Context.subscriptions.push(
+            languages.registerDocumentDropEditProvider(
+                { scheme: 'untitled' },
+                new ObjectDropProvider()
+            )
+        );
+
+        // Register sql files
+        Context.subscriptions.push(
+            languages.registerDocumentDropEditProvider(
+                { scheme: 'file', language: 'sql' },
+                new ObjectDropProvider()
+            )
+        );
+        console.log("Registered object drop provider");
+        this.isRegistered = true;
+    };
+
+}


### PR DESCRIPTION
PR implementing requested object-name drag and drop functionality requested in #1135 & [#10](https://github.com/ScriptPup/sqltools-teradata-driver/issues/10).

Dragging resource groups does nothing (as they are just logical containers and mean nothing to the underlying SQL engine).

![efe6d2a6-70cf-4976-a5aa-3e38d924b328](https://user-images.githubusercontent.com/6163646/235359426-ed5448c9-9d3c-4003-ba04-1d649b61dd59.gif)

Thank you for your contribution! 
Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] You have made the needed changes to the docs (N/A)
- [x] You have written a description of what is the purpose of this pull request above

