### PR TITLE
`//`(Floor Division) on CockroachDB query formatting fixed

### DIFF
--- a/packages/formatter/src/core/Tokenizer.ts
+++ b/packages/formatter/src/core/Tokenizer.ts
@@ -39,7 +39,7 @@ export default class Tokenizer {
     this.WHITESPACE_REGEX = /^(\s+)/u;
     this.NUMBER_REGEX = /^((-\s*)?[0-9]+(\.[0-9]+)?|0x[0-9a-fA-F]+|0b[01]+|([a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}))\b/u;
     this.AMBIGUOS_OPERATOR_REGEX = /^(\?\||\?&)/u;
-    this.OPERATOR_REGEX = /^(<=>|!=|<>|>>|<<|==|<=|>=|!<|!>|\|\|\/|\|\/|\|\||~~\*|~~|!~~\*|!~~|~\*|!~\*|!~|:=|=>|&&|@>|<@|#-|@@|@|.)/u;
+    this.OPERATOR_REGEX = /^(<=>|!=|<>|>>|<<|==|<=|>=|!<|!>|\|\|\/|\|\/|\|\||\/\/|~~\*|~~|!~~\*|!~~|~\*|!~\*|!~|:=|=>|&&|@>|<@|#-|@@|@|.)/u;
     this.NO_SPACE_OPERATOR_REGEX = /^(::|->>|->|#>>|#>)/u;
 
     this.BLOCK_COMMENT_REGEX = /^(\/\*[^]*?(?:\*\/|$))/u;

--- a/packages/formatter/test/behavesLikeSqlFormatter.ts
+++ b/packages/formatter/test/behavesLikeSqlFormatter.ts
@@ -371,6 +371,7 @@ export default function behavesLikeSqlFormatter(language?: any) {
         expect(format("foo && bar")).toBe("foo && bar");
         expect(format("foo := bar")).toBe("foo := bar");
         expect(format("foo => bar")).toBe("foo => bar"); // Snowflake, TimescaleDB
+        expect(format("foo // bar")).toBe("foo // bar"); // CockroachDB floor division
         expect(format("foo <=> bar")).toBe("foo <=> bar");
     });
 


### PR DESCRIPTION
The floor division opeator `//` is special to CockroachDB I think. I found it in other DBMS' Documentation but only for comments (and none of them are officiall supported by `sqltools`), so keeping these two slashes without whitespace inbetween no matter what should always at least be "more valid" than splitting them apart.
Therefore I do not expect unwanted side effects because of this change.

fixes #1234 

Thank you for your contribution! 
Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
      _There are warnings, but not because of my change_
- [ ] You have made the needed changes to the docs
- [x] You have written a description of what is the purpose of this pull request above
