### PR TITLE
Fixed broken links to documentation for driver-specific options

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -625,7 +625,7 @@
                                     "null",
                                     "object"
                                 ],
-                                "markdownDescription": "See https://vscode-sqltools.mteixeira.dev/connections/mssql#1-1-specific-options for more details.",
+                                "markdownDescription": "See https://vscode-sqltools.mteixeira.dev/en/drivers/microsoft-sql-server-azure#11-specific-options for more details.",
                                 "default": {},
                                 "properties": {
                                     "encrypt": {
@@ -643,7 +643,7 @@
                                     "object",
                                     "null"
                                 ],
-                                "description": "See https://vscode-sqltools.mteixeira.dev/connections/mysql#2-mysqloptions for more details.",
+                                "description": "See https://vscode-sqltools.mteixeira.dev/en/drivers/my-sql#2-mysqloptions for more details.",
                                 "default": {},
                                 "properties": {
                                     "authProtocol": {
@@ -671,7 +671,7 @@
                                     "null"
                                 ],
                                 "default": {},
-                                "markdownDescription": "See https://vscode-sqltools.mteixeira.dev/connections/postgresql#1-1-specific-options for more details.",
+                                "markdownDescription": "See https://vscode-sqltools.mteixeira.dev/en/drivers/postgre-sql#11-specific-options for more details.",
                                 "properties": {
                                     "ssl": {
                                         "type": [
@@ -689,7 +689,15 @@
                                     "null"
                                 ],
                                 "default": {},
-                                "markdownDescription": "See https://vscode-sqltools.mteixeira.dev/connections/oracledb#2-3-specific-options for more details."
+                                "markdownDescription": "See https://node-oracledb.readthedocs.io/en/latest/api_manual/oracledb.html#createpoolparams for more details."
+                            },
+                            "cqlOptions": {
+                                "type": [
+                                    "object",
+                                    "null"
+                                ],
+                                "default": {},
+                                "markdownDescription": "See https://docs.datastax.com/en/developer/nodejs-driver/4.1/api/type.ClientOptions/ for more details."
                             },
                             "connectionTimeout": {
                                 "type": "number",

--- a/packages/extension/src/api/error-handler.ts
+++ b/packages/extension/src/api/error-handler.ts
@@ -29,7 +29,7 @@ namespace ErrorHandler {
         commands.executeCommand(`${EXT_NAMESPACE}.showOutputChannel`);
         break;
       case 'Help!':
-        openExternal(`${DOCS_ROOT_URL}/connections/${error.data.driver.toLowerCase()}#${typeof error.code === 'string' ? error.code : error.name}`);
+        openExternal(`${DOCS_ROOT_URL}/en/drivers/${error.data.driver.toLowerCase()}#${typeof error.code === 'string' ? error.code : error.name}`);
         break;
     }
   }

--- a/packages/plugins/connection-manager/dependency-manager/extension.ts
+++ b/packages/plugins/connection-manager/dependency-manager/extension.ts
@@ -86,7 +86,7 @@ export default class DependencyManager implements IExtensionPlugin {
           }
           break;
         case readMore:
-          openExternal(`${DOCS_ROOT_URL}/driver/${conn.driver ? conn.driver.toLowerCase() : ''}?umd_source=vscode&utm_medium=driver&utm_campaign=dependencies`);
+          openExternal(`${DOCS_ROOT_URL}/en/drivers/${conn.driver ? conn.driver.toLowerCase() : ''}?umd_source=vscode&utm_medium=driver&utm_campaign=dependencies`);
           break;
       }
     } catch (error) {

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -133,28 +133,28 @@ export interface IConnection<DriverOptions = any> {
    */
   connectString?: string;
   /**
-   * MSSQL specific driver options. See https://vscode-sqltools.mteixeira.dev/connections/mssql#1-1-specific-options
+   * MSSQL specific driver options. See https://vscode-sqltools.mteixeira.dev/en/drivers/microsoft-sql-server-azure#11-specific-options
    * @type {any}
    * @memberof IConnection
    */
   mssqlOptions?: { encrypt?: boolean };
 
   /**
-   * MySQL specific driver options
+   * MySQL specific driver options. See https://vscode-sqltools.mteixeira.dev/en/drivers/my-sql#2-mysqloptions
    * @type {any}
    * @memberof IConnection
    */
   mysqlOptions?: DriverOptions;
 
   /**
-   * PostgreSQL/Redshift specific driver options. See https://vscode-sqltools.mteixeira.dev/connections/postgresql#1-1-specific-options
+   * PostgreSQL/Redshift specific driver options. See https://vscode-sqltools.mteixeira.dev/en/drivers/postgre-sql#11-specific-options
    * @type {any}
    * @memberof IConnection
    */
   pgOptions?: DriverOptions;
 
   /**
-   * OracleDB specific driver options (pool). See https://github.com/oracle/node-oracledb/blob/master/doc/api.md#createpoolpoolattrs
+   * OracleDB specific driver options (pool). See https://node-oracledb.readthedocs.io/en/latest/api_manual/oracledb.html#createpoolparams
    * @type {PoolAttributes}
    * @memberof IConnection
    */

--- a/packages/util/decorators/ls-decorate-exception.ts
+++ b/packages/util/decorators/ls-decorate-exception.ts
@@ -18,6 +18,7 @@ export default function decorateLSException(e: Error & { code?: number; data?: {
       mysqlOptions: conn.mysqlOptions,
       pgOptions: conn.pgOptions,
       oracleOptions: conn.oracleOptions,
+      cqlOptions: conn.cqlOptions,
     };
   }
   return new DecoratedException<typeof e.data>(e, data);


### PR DESCRIPTION
1. Fixed broken links to documentation
2. Synced driver-specific options available in [packages/extension/package.json](https://github.com/mtxr/vscode-sqltools/blob/dev/packages/extension/package.json) and [packages/types/index.d.ts](https://github.com/mtxr/vscode-sqltools/blob/dev/packages/types/index.d.ts)
3. Added forgotten driver-specific cqlOptions to `decorateLSException()`