### PR TITLE
MySql Driver Configuration Bug Fix (EnableSsl)

### DIFF
--- a/packages/driver.mysql/src/extension.ts
+++ b/packages/driver.mysql/src/extension.ts
@@ -71,7 +71,14 @@ export async function activate(extContext: vscode.ExtensionContext): Promise<IDr
         propsToRemove.push('askForPassword');
       }
       propsToRemove.forEach(p => delete connInfo[p]);
-
+      connInfo.mysqlOptions = connInfo.mysqlOptions || {};
+      if (connInfo.mysqlOptions.enableSsl === 'Disabled') {
+        delete connInfo.mysqlOptions.ssl;
+      }
+      if (typeof connInfo.mysqlOptions.ssl === 'object' && Object.keys(connInfo.mysqlOptions.ssl).length === 0) {
+        connInfo.mysqlOptions.enableSsl = 'Disabled';
+        delete connInfo.mysqlOptions.ssl;
+      }
       return connInfo;
     },
     parseBeforeEditConnection: ({ connInfo }) => {


### PR DESCRIPTION
If enableSSL is ticked but object is left empty we now disable enableSSL

If enableSsl is false, we delete the object.

I'm not sure if their is use case for having enableSsl as true but not specifying parameters. Sorry!

Fixes #1270 

