### PR TITLE
Remove 'Edit this page' from docs

### DIFF
--- a/docs/src/components/PageContent/PageContent.astro
+++ b/docs/src/components/PageContent/PageContent.astro
@@ -7,10 +7,9 @@ import type { MarkdownHeading } from 'astro';
 type Props = {
   frontmatter: Frontmatter;
   headings: MarkdownHeading[];
-  githubEditUrl: string;
 };
 
-const { frontmatter, headings, githubEditUrl } = Astro.props as Props;
+const { frontmatter, headings } = Astro.props as Props;
 const title = frontmatter.title;
 ---
 
@@ -23,7 +22,7 @@ const title = frontmatter.title;
     <slot />
   </section>
   <nav class="block sm:hidden">
-    <MoreMenu editHref={githubEditUrl} />
+    <MoreMenu />
   </nav>
 </article>
 

--- a/docs/src/components/RightSidebar/MoreMenu.astro
+++ b/docs/src/components/RightSidebar/MoreMenu.astro
@@ -2,40 +2,14 @@
 import * as CONFIG from '../../config';
 
 type Props = {
-  editHref: string;
 };
 
-const { editHref } = Astro.props as Props;
 const showMoreSection = CONFIG.COMMUNITY_INVITE_URL;
 ---
 
 {showMoreSection && <h2 class="heading">More</h2>}
 <ul>
   {
-    editHref && (
-      <li class={`heading-link depth-2`}>
-        <a class="edit-on-github" href={editHref} target="_blank">
-          <svg
-            aria-hidden="true"
-            focusable="false"
-            data-prefix="fas"
-            data-icon="pen"
-            class="svg-inline--fa fa-pen fa-w-16"
-            role="img"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 512 512"
-            height="1em"
-            width="1em"
-          >
-            <path
-              fill="currentColor"
-              d="M290.74 93.24l128.02 128.02-277.99 277.99-114.14 12.6C11.35 513.54-1.56 500.62.14 485.34l12.7-114.22 277.9-277.88zm207.2-19.06l-60.11-60.11c-18.75-18.75-49.16-18.75-67.91 0l-56.55 56.55 128.02 128.02 56.55-56.55c18.75-18.76 18.75-49.16 0-67.91z"
-            />
-          </svg>
-          <span>Edit this page</span>
-        </a>
-      </li>
-    )
   }
   {
     CONFIG.COMMUNITY_INVITE_URL && (

--- a/docs/src/components/RightSidebar/RightSidebar.astro
+++ b/docs/src/components/RightSidebar/RightSidebar.astro
@@ -5,16 +5,15 @@ import type { MarkdownHeading } from 'astro';
 
 type Props = {
 	headings: MarkdownHeading[];
-	githubEditUrl: string;
 };
 
-const { headings, githubEditUrl } = Astro.props as Props;
+const { headings } = Astro.props as Props;
 ---
 
 <nav class="sidebar-nav" aria-labelledby="grid-right">
 	<div class="sidebar-nav-inner">
 		<TableOfContents client:media="(min-width: 50em)" headings={headings} />
-		<MoreMenu editHref={githubEditUrl} />
+		<MoreMenu />
 	</div>
 </nav>
 

--- a/docs/src/config.ts
+++ b/docs/src/config.ts
@@ -30,8 +30,6 @@ export const KNOWN_LANGUAGES = {
 } as const;
 export const KNOWN_LANGUAGE_CODES = Object.values(KNOWN_LANGUAGES);
 
-export const GITHUB_EDIT_URL = `https://github.com/mtxr/vscode-sqltools/blob/dev/docs`;
-
 export const COMMUNITY_INVITE_URL = ``;
 
 // @TODO waiting for algolia doc search approval

--- a/docs/src/layouts/MainLayout.astro
+++ b/docs/src/layouts/MainLayout.astro
@@ -18,7 +18,6 @@ const { frontmatter, headings } = Astro.props as Props;
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 const currentPage = Astro.url.pathname;
 const currentFile = `src/pages${currentPage.replace(/\/$/, '')}.mdx`;
-const githubEditUrl = `${CONFIG.GITHUB_EDIT_URL}/${currentFile}`;
 ---
 
 <html dir={frontmatter.dir ?? 'ltr'} lang={frontmatter.lang ?? 'en-us'} class="initial">
@@ -123,12 +122,12 @@ const githubEditUrl = `${CONFIG.GITHUB_EDIT_URL}/${currentFile}`;
         <LeftSidebar currentPage={currentPage} />
       </aside>
       <div id="grid-main">
-        <PageContent frontmatter={frontmatter} headings={headings} githubEditUrl={githubEditUrl}>
+        <PageContent frontmatter={frontmatter} headings={headings}>
           <slot />
         </PageContent>
       </div>
       <aside id="grid-right" class="grid-sidebar" title="Table of Contents">
-        <RightSidebar headings={headings} githubEditUrl={githubEditUrl} />
+        <RightSidebar headings={headings} />
       </aside>
     </main>
     <Footer path={currentFile} />


### PR DESCRIPTION
This fixes #1272 by removing the edit option. Contributors should instead follow the steps given at https://vscode-sqltools.mteixeira.dev/en/contributing/documentation