### PR TITLE
Add CSV export format options

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -841,6 +841,43 @@
                     "default": "prompt",
                     "description": "Default mode for results Open command."
                 },
+                "sqltools.csvExport.delimiter": {
+                    "type": "string",
+                    "minLength": 1,
+                    "default": ",",
+                    "description": "CSV field delimiter, one character only."
+                },
+                "sqltools.csvExport.header": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Display the column names on the first line."
+                },
+                "sqltools.csvExport.quote": {
+                    "type": "string",
+                    "default": "\"",
+                    "description": "The quote characters, an empty value will preserve the original field."
+                },
+                "sqltools.csvExport.quoted": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Quote all the non-empty fields even if not required."
+                },
+                "sqltools.csvExport.quoted_empty": {
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Quote empty fields and overrides `#sqltools.csvExport.quoted_string#` on empty strings when defined."
+                },
+                "sqltools.csvExport.quoted_string": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Quote all fields of type string even if not required."
+                },
+                "sqltools.csvExport.record_delimiter": {
+                    "type": "string",
+                    "minLength": 1,
+                    "default": "unix",
+                    "markdownDescription": "String used to delimit record rows or a special value: `unix` (`\\n`), `mac` (`\\r`), `windows` (`\\r\\n`), `ascii` (`\\u001e`), or `unicode` (`\\u2028`)."
+                },
                 "sqltools.useNodeRuntime": {
                     "type": [
                         "null",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -859,7 +859,7 @@
                 },
                 "sqltools.csvExport.quoted": {
                     "type": "boolean",
-                    "default": true,
+                    "default": false,
                     "description": "Quote all the non-empty fields even if not required."
                 },
                 "sqltools.csvExport.quoted_empty": {
@@ -869,7 +869,7 @@
                 },
                 "sqltools.csvExport.quoted_string": {
                     "type": "boolean",
-                    "default": false,
+                    "default": true,
                     "description": "Quote all fields of type string even if not required."
                 },
                 "sqltools.csvExport.record_delimiter": {

--- a/packages/plugins/connection-manager/language-server.ts
+++ b/packages/plugins/connection-manager/language-server.ts
@@ -62,8 +62,8 @@ export default class ConnectionManagerPlugin implements ILanguageServerPlugin {
     return formatType === 'json'
       ? JSON.stringify(results, null, 2)
       : csvStringify(results, {
-        columns: cols,
         ...ConfigRO.csvExport,
+        columns: cols,
       });
   };
 

--- a/packages/plugins/connection-manager/language-server.ts
+++ b/packages/plugins/connection-manager/language-server.ts
@@ -63,9 +63,7 @@ export default class ConnectionManagerPlugin implements ILanguageServerPlugin {
       ? JSON.stringify(results, null, 2)
       : csvStringify(results, {
         columns: cols,
-        header: true,
-        quoted_string: true,
-        quoted_empty: true,
+        ...ConfigRO.csvExport,
       });
   };
 

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -525,7 +525,7 @@ export interface ICSVExportOptions {
   /**
    * Quote all non-empty fields
    * @type {boolean}
-   * @default true
+   * @default false
    * @memberof ICSVExportOptions
    */
   quoted?: boolean;
@@ -539,7 +539,7 @@ export interface ICSVExportOptions {
   /**
    * Quote all string fields
    * @type {boolean}
-   * @default false
+   * @default true
    * @memberof ICSVExportOptions
    */
   quoted_string?: boolean;

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -500,6 +500,58 @@ export interface IResultsOptions {
   };
 }
 
+export interface ICSVExportOptions {
+  /**
+   * Field delimiter
+   * @type {string}
+   * @default ','
+   * @memberof ICSVExportOptions
+   */
+  delimiter?: string;
+  /**
+   * Include header line
+   * @type {boolean}
+   * @default true
+   * @memberof ICSVExportOptions
+   */
+  header?: boolean;
+  /**
+   * Quote characters
+   * @type {string}
+   * @default '"'
+   * @memberof ICSVExportOptions
+   */
+  quote?: string;
+  /**
+   * Quote all non-empty fields
+   * @type {boolean}
+   * @default true
+   * @memberof ICSVExportOptions
+   */
+  quoted?: boolean;
+  /**
+   * Quote empty fields
+   * @type {boolean}
+   * @default true
+   * @memberof ICSVExportOptions
+   */
+  quoted_empty?: boolean;
+  /**
+   * Quote all string fields
+   * @type {boolean}
+   * @default false
+   * @memberof ICSVExportOptions
+   */
+  quoted_string?: boolean;
+  /**
+   * Record delimiter or special value
+   * @type {string}
+   * @default 'unix'
+   * @memberof ICSVExportOptions
+   */
+  record_delimiter?: string;
+}
+
 export interface ISettings {
   /**
    * Disable new release notifications.
@@ -606,6 +658,13 @@ export interface ISettings {
    * @memberof ISettings
    */
   defaultOpenType?: 'prompt' | 'csv' | 'json';
+
+  /**
+   * CSV export format options
+   * @type {ICSVExportOptions}
+   * @memberof ISettings
+   */
+  csvExport?: ICSVExportOptions;
 
   /**
    * Enable node runtime usage.


### PR DESCRIPTION
This PR adds options from csv-stringify to the extension settings, allowing users to customize the format of the generated CSV when exporting. The new settings are all in the group `sqltools.csvExport`, which allows to directly pass all values at once to csv-stringify. The default settings reflect the current option values.

The changes made here partly close #739. I was planning to add an option to change the CSV field separator and ended up adding some additional related options that might be useful to tweak the resulting CSV. In #739, the decimal separator is also mentioned. I don't handle this here, as it does not seem specifically related to the CSV format (could also apply to the JSON export).

----

Thank you for your contribution! 
Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] You have made the needed changes to the docs
- [x] You have written a description of what is the purpose of this pull request above
