### PR TITLE
Delay showing SQL CONSOLE tab in Panel until first query is run

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -989,7 +989,8 @@
             "sqltoolsPanelContainer": [
                 {
                     "id": "sqltoolsViewConsoleMessages",
-                    "name": "Messages"
+                    "name": "Messages",
+                    "when": "sqltools.consoleMessages.active"
                 }
             ]
         },

--- a/packages/plugins/connection-manager/explorer/index.ts
+++ b/packages/plugins/connection-manager/explorer/index.ts
@@ -234,6 +234,7 @@ export class ConnectionExplorer implements TreeDataProvider<SidebarTreeItem>, Tr
 
 export class MessagesProvider implements TreeDataProvider<TreeItem> {
   private items: TreeItem[] = [];
+  private active: boolean = false;
   private _onDidChangeTreeData: EventEmitter<TreeItem> = new EventEmitter();
   public readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
   getTreeItem(element: TreeItem): TreeItem | Thenable<TreeItem> {
@@ -249,6 +250,10 @@ export class MessagesProvider implements TreeDataProvider<TreeItem> {
   }
 
   addMessages = (messages: NSDatabase.IResult['messages'] = []) => {
+    if (!this.active && messages.length > 0) {
+      this.active = true;
+      commands.executeCommand('setContext', `${EXT_NAMESPACE}.consoleMessages.active`, true);
+    }
     this.items = messages.map(m => {
       let item: TreeItem;
       if (typeof m === 'string') {


### PR DESCRIPTION
Aims to improve the case described in https://github.com/mtxr/vscode-sqltools/discussions/1188 by delaying display of this view container until the first time a message is written to the Messages view that lives there by default.