### PR TITLE
Fix broken doc link on "Read More" button on SQLite driver dependency installation message

### DIFF
--- a/docs/src/config.ts
+++ b/docs/src/config.ts
@@ -23,6 +23,7 @@ export type Frontmatter = {
 	dir?: 'ltr' | 'rtl';
 	ogLocale?: string;
 	lang?: string;
+	redirect?: string;
 };
 
 export const KNOWN_LANGUAGES = {

--- a/docs/src/layouts/Redirect.astro
+++ b/docs/src/layouts/Redirect.astro
@@ -1,0 +1,23 @@
+---
+import * as CONFIG from '../config';
+
+type Props = {
+  frontmatter: CONFIG.Frontmatter;
+};
+
+const { frontmatter } = Astro.props as Props;
+---
+
+<html dir={frontmatter.dir ?? 'ltr'} lang={frontmatter.lang ?? 'en-us'} class="initial">
+  <head>
+    {frontmatter.redirect ? (
+    <meta 
+      http-equiv="refresh" 
+      content={ `0; url=${ frontmatter.redirect }` } 
+    />
+    ) : null}
+  </head>
+
+  <body>
+  </body>
+</html>

--- a/docs/src/pages/en/contributing/documentation.mdx
+++ b/docs/src/pages/en/contributing/documentation.mdx
@@ -10,7 +10,7 @@ Here is the process for improving this documentation.
 
 1. Fork the repository.
 2. Clone your fork.
-3. Open the project workspace (`vscode-sqltools.code-workspace`) withj VS Code.
+3. Open the project workspace (`vscode-sqltools.code-workspace`) with VS Code.
 4. Create a branch from the `dev` branch.
 5. Expand the `docs` root folder.
 6. Edit pages. For example this page is at `src/pages/en/contributing/documentation.mdx` within `docs`

--- a/docs/src/pages/en/drivers/sqlite.mdx
+++ b/docs/src/pages/en/drivers/sqlite.mdx
@@ -1,0 +1,5 @@
+---
+title: SQLite redirect page for Read More button of Dependency Manager dialog
+layout: ../../../layouts/Redirect.astro
+redirect: sq-lite
+---


### PR DESCRIPTION
This PR fixes #1330 by adding support for redirection in the documentation pages. This is necessary because Dependency Manager's message always opens a page named exactly the same as the `driver` property used in connection definitions.