### PR TITLE
allow sessionFilesFolder to be relative to the workspace folder if the path provided in the config is not absolute

### DIFF
--- a/packages/plugins/connection-manager/extension.ts
+++ b/packages/plugins/connection-manager/extension.ts
@@ -168,7 +168,7 @@ export class ConnectionManagerPlugin implements IExtensionPlugin {
 
     if (Config.sessionFilesFolder && Config.sessionFilesFolder != '') {
       baseFolder = Uri.file(Config.sessionFilesFolder);
-      if(!path.isAbsolute(Config.sessionFilesFolder && workspace.workspaceFolders && workspace.workspaceFolders.length)){
+      if(!path.isAbsolute(Config.sessionFilesFolder) && workspace.workspaceFolders && workspace.workspaceFolders.length){
         baseFolder = path.resolve(workspace.workspaceFolders[0].uri, Config.sessionFilesFolder)
       }
     }

--- a/packages/plugins/connection-manager/extension.ts
+++ b/packages/plugins/connection-manager/extension.ts
@@ -168,6 +168,9 @@ export class ConnectionManagerPlugin implements IExtensionPlugin {
 
     if (Config.sessionFilesFolder && Config.sessionFilesFolder != '') {
       baseFolder = Uri.file(Config.sessionFilesFolder);
+      if(!path.isAbsolute(Config.sessionFilesFolder && workspace.workspaceFolders && workspace.workspaceFolders.length)){
+        baseFolder = path.resolve(workspace.workspaceFolders[0].uri, Config.sessionFilesFolder)
+      }
     }
 
     const sessionFilePath = path.resolve(baseFolder.fsPath, getSessionBasename(conn.name));


### PR DESCRIPTION
Addresses #1254, and potentially helps with #1010 

This PR aims allows the session file folder to be relative to the workspace if the path in the config is a relative path.
Currently setting the session file folder to "./something" will cause it to create folder "/something" instead.

----

Thank you for your contribution! 
Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] You have made the needed changes to the docs
- [x] You have written a description of what is the purpose of this pull request above
