### PR TITLE
Multiple MSSQL driver improvements

### DIFF
--- a/packages/driver.mssql/connection.schema.json
+++ b/packages/driver.mssql/connection.schema.json
@@ -69,6 +69,10 @@
           "type": "boolean",
           "default": true
         },
+        "trustServerCertificate": {
+          "type": "boolean",
+          "default": false
+        },
         "tdsVersion": {
           "type": "string",
           "enum": [

--- a/packages/driver.mssql/connection.schema.json
+++ b/packages/driver.mssql/connection.schema.json
@@ -44,7 +44,8 @@
     "connectionTimeout": {
       "title": "Connection Timeout",
       "type": "integer",
-      "minimum": 0
+      "minimum": 0,
+      "default": 15
     },
     "mssqlOptions": {
       "type": "object",

--- a/packages/driver.mssql/src/ls/driver.ts
+++ b/packages/driver.mssql/src/ls/driver.ts
@@ -16,7 +16,7 @@ export default class MSSQL extends AbstractDriver<MSSQLLib.ConnectionPool, any> 
       return this.connection;
     }
 
-    const { encrypt, ...mssqlOptions }: any = this.credentials.mssqlOptions || { encrypt: true };
+    const { encrypt, trustServerCertificate, ...mssqlOptions }: any = this.credentials.mssqlOptions || { encrypt: true };
 
     let encryptAttempt = typeof encrypt !== 'undefined'
       ? encrypt : true;
@@ -42,6 +42,7 @@ export default class MSSQL extends AbstractDriver<MSSQLLib.ConnectionPool, any> 
       options: {
         ...((mssqlOptions || {}).options || {}),
         encrypt: encryptAttempt,
+        trustServerCertificate: trustServerCertificate,
       },
     });
 

--- a/packages/driver.mssql/src/ls/driver.ts
+++ b/packages/driver.mssql/src/ls/driver.ts
@@ -49,6 +49,10 @@ export default class MSSQL extends AbstractDriver<MSSQLLib.ConnectionPool, any> 
       pool.on('error', reject);
       pool.connect().then(resolve).catch(reject);
     }).catch(e => {
+      // The errors below are relevant to database configuration
+      if (e.code === "ESOCKET" || e.code === "ELOGIN" || e.code === "EINSTLOOKUP") {
+        throw e;
+      }
       if (this.retryCount === 0) {
         this.retryCount++;
         return this.open(!encryptAttempt)

--- a/packages/driver.mssql/src/ls/queries.ts
+++ b/packages/driver.mssql/src/ls/queries.ts
@@ -111,7 +111,7 @@ SELECT name AS label,
   name AS "database",
   '${ContextValue.DATABASE}' AS "type",
   'database' AS "detail"
-FROM MASTER.dbo.sysdatabases
+FROM sys.databases
 WHERE name NOT IN ('master', 'model', 'msdb', 'tempdb')
 `;
 export const searchTables: IBaseQueries['searchTables'] = queryFactory`


### PR DESCRIPTION
Describe here what is this PR about and what we are achieving merging this.

- Use Microsoft recommended system table to get a list of databases
- Better error handling: Throw database configuration errors rather than retrying
- Set default connection timeout to 15 - same as the tedious driver
- Add tedious specific option - trustServerCertificate
----

Thank you for your contribution! 
Before submitting this PR, please make sure:

- [ ] Your code builds clean without any errors or warnings
- [x] You have made the needed changes to the docs
- [x] You have written a description of what is the purpose of this pull request above
