### PR TITLE
mssql QoL changes and a major bug fix

### DIFF
--- a/packages/driver.mssql/connection.schema.json
+++ b/packages/driver.mssql/connection.schema.json
@@ -121,7 +121,6 @@
           "required": [
             "server",
             "port",
-            "database",
             "username"
           ]
         },
@@ -149,7 +148,6 @@
           },
           "required": [
             "socketPath",
-            "database",
             "username"
           ]
         },

--- a/packages/driver.mssql/src/ls/driver.ts
+++ b/packages/driver.mssql/src/ls/driver.ts
@@ -157,7 +157,15 @@ export default class MSSQL extends AbstractDriver<MSSQLLib.ConnectionPool, any> 
   private async getChildrenForGroup({ parent, item }: Arg0<IConnectionDriver['getChildrenForItem']>) {
     switch (item.childType) {
       case ContextValue.SCHEMA:
-        return this.queryResults(this.queries.fetchSchemas(parent as NSDatabase.IDatabase));
+        try {
+          const result = await this.queryResults(
+            this.queries.fetchSchemas(parent as NSDatabase.IDatabase)
+          );
+          return result;
+        } catch (error) {
+          this.close();
+          return [];
+        }
       case ContextValue.TABLE:
         return this.queryResults(this.queries.fetchTables(parent as NSDatabase.ISchema));
       case ContextValue.VIEW:

--- a/packages/driver.mssql/src/ls/queries.ts
+++ b/packages/driver.mssql/src/ls/queries.ts
@@ -34,20 +34,20 @@ SELECT
   (CASE WHEN LOWER(TC.CONSTRAINT_TYPE) = 'primary key' THEN 1 ELSE 0 END) as "isPk",
   (CASE WHEN LOWER(TC.CONSTRAINT_TYPE) = 'foreign key' THEN 1 ELSE 0 END) as "isFk"
 FROM
-  INFORMATION_SCHEMA.COLUMNS C
-  LEFT JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS KCU ON (
+  ${p => p.database ? `${escapeTableName({ database: p.database, schema: "INFORMATION_SCHEMA", label: "COLUMNS" })}` : 'INFORMATION_SCHEMA.COLUMNS'} C
+  LEFT JOIN ${p => p.database ? `${escapeTableName({ database: p.database, schema: "INFORMATION_SCHEMA", label: "KEY_COLUMN_USAGE" })}` : 'INFORMATION_SCHEMA.KEY_COLUMN_USAGE'} AS KCU ON (
     C.TABLE_CATALOG = KCU.TABLE_CATALOG
     AND C.TABLE_NAME = KCU.TABLE_NAME
     AND C.TABLE_SCHEMA = KCU.TABLE_SCHEMA
     AND C.TABLE_CATALOG = KCU.TABLE_CATALOG
     AND C.COLUMN_NAME = KCU.COLUMN_NAME
   )
-  LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS TC ON (
+  LEFT JOIN ${p => p.database ? `${escapeTableName({ database: p.database, schema: "INFORMATION_SCHEMA", label: "TABLE_CONSTRAINTS" })}` : 'INFORMATION_SCHEMA.TABLE_CONSTRAINTS'} AS TC ON (
     TC.CONSTRAINT_NAME = KCU.CONSTRAINT_NAME
     AND TC.TABLE_SCHEMA = KCU.TABLE_SCHEMA
     AND TC.TABLE_CATALOG = KCU.TABLE_CATALOG
   )
-  JOIN INFORMATION_SCHEMA.TABLES AS T ON C.TABLE_NAME = T.TABLE_NAME
+  JOIN ${p => p.database ? `${escapeTableName({ database: p.database, schema: "INFORMATION_SCHEMA", label: "TABLES" })}` : 'INFORMATION_SCHEMA.TABLES'} AS T ON C.TABLE_NAME = T.TABLE_NAME
   AND C.TABLE_SCHEMA = T.TABLE_SCHEMA
   AND C.TABLE_CATALOG = T.TABLE_CATALOG
 WHERE
@@ -79,7 +79,7 @@ SELECT
   T.TABLE_SCHEMA AS "schema",
   T.TABLE_CATALOG AS "database",
   CONVERT(BIT, CASE WHEN T.TABLE_TYPE = 'BASE TABLE' THEN 0 ELSE 1 END) AS "isView"
-FROM INFORMATION_SCHEMA.TABLES AS T
+FROM ${p => p.database ? `${escapeTableName({ database: p.database, schema: "INFORMATION_SCHEMA", label: "TABLES" })}` : 'INFORMATION_SCHEMA.TABLES'} AS T
 WHERE
   T.TABLE_SCHEMA = '${p => p.schema}'
   AND T.TABLE_CATALOG = '${p => p.database}'
@@ -98,7 +98,7 @@ SELECT
   '${ContextValue.SCHEMA}' as "type",
   'group-by-ref-type' as "iconId",
   catalog_name as "database"
-FROM information_schema.schemata
+FROM ${p => p.database ? `${escapeTableName({ database: p.database, schema: "information_schema", label: "schemata" })}` : 'information_schema.schemata'}
 WHERE
   LOWER(schema_name) NOT IN ('information_schema', 'sys', 'guest')
   AND LOWER(schema_name) NOT LIKE 'db\\_%' ESCAPE '\\'
@@ -123,7 +123,7 @@ SELECT
   (CASE WHEN T.TABLE_TYPE = 'BASE TABLE' THEN 0 ELSE 1 END) AS "isView",
   (CASE WHEN T.TABLE_TYPE = 'BASE TABLE' THEN 'table' ELSE 'view' END) AS description,
   ('[' + T.TABLE_CATALOG + '].[' + T.TABLE_SCHEMA + '].[' + T.TABLE_NAME + ']') as detail
-FROM INFORMATION_SCHEMA.TABLES AS T
+FROM ${p => p.database ? `${escapeTableName({ database: p.database, schema: "INFORMATION_SCHEMA", label: "TABLES" })}` : 'INFORMATION_SCHEMA.TABLES'} AS T
 WHERE
   LOWER(T.TABLE_SCHEMA) NOT IN ('information_schema', 'sys', 'guest')
   AND LOWER(T.TABLE_SCHEMA) NOT LIKE 'db\\_%' ESCAPE '\\'
@@ -152,20 +152,20 @@ SELECT
   (CASE WHEN LOWER(TC.CONSTRAINT_TYPE) = 'primary key' THEN 1 ELSE 0 END) as "isPk",
   (CASE WHEN LOWER(TC.CONSTRAINT_TYPE) = 'foreign key' THEN 1 ELSE 0 END) as "isFk"
 FROM
-  INFORMATION_SCHEMA.COLUMNS C
-  LEFT JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS KCU ON (
+  ${p => p.tables[0].database ? `${escapeTableName({ database: p.tables[0].database, schema: "INFORMATION_SCHEMA", label: "COLUMNS" })}` : 'INFORMATION_SCHEMA.COLUMNS'} C
+  LEFT JOIN ${p => p.tables[0].database ? `${escapeTableName({ database: p.tables[0].database, schema: "INFORMATION_SCHEMA", label: "KEY_COLUMN_USAGE" })}` : 'INFORMATION_SCHEMA.KEY_COLUMN_USAGE'} AS KCU ON (
     C.TABLE_CATALOG = KCU.TABLE_CATALOG
     AND C.TABLE_NAME = KCU.TABLE_NAME
     AND C.TABLE_SCHEMA = KCU.TABLE_SCHEMA
     AND C.TABLE_CATALOG = KCU.TABLE_CATALOG
     AND C.COLUMN_NAME = KCU.COLUMN_NAME
   )
-  LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS TC ON (
+  LEFT JOIN ${p => p.tables[0].database ? `${escapeTableName({ database: p.tables[0].database, schema: "INFORMATION_SCHEMA", label: "TABLE_CONSTRAINTS" })}` : 'INFORMATION_SCHEMA.TABLE_CONSTRAINTS'} AS TC ON (
     TC.CONSTRAINT_NAME = KCU.CONSTRAINT_NAME
     AND TC.TABLE_SCHEMA = KCU.TABLE_SCHEMA
     AND TC.TABLE_CATALOG = KCU.TABLE_CATALOG
   )
-  JOIN INFORMATION_SCHEMA.TABLES AS T ON C.TABLE_NAME = T.TABLE_NAME
+  JOIN ${p => p.tables[0].database ? `${escapeTableName({ database: p.tables[0].database, schema: "INFORMATION_SCHEMA", label: "TABLES" })}` : 'INFORMATION_SCHEMA.TABLES'} AS T ON C.TABLE_NAME = T.TABLE_NAME
   AND C.TABLE_SCHEMA = T.TABLE_SCHEMA
   AND C.TABLE_CATALOG = T.TABLE_CATALOG
 WHERE LOWER(C.TABLE_SCHEMA) NOT IN ('information_schema', 'sys', 'guest')


### PR DESCRIPTION
Describe here what is this PR about and what we are achieving merging this.
- Database is optional now in connection UI
- Use database specific information_schema in queries, fixing empty schemas, tables/views when clicking on a database that is not "master"
- Return empty list when schema is inaccessible, fixing "sqltools.getChildrenForTreeItem" when clicking on inaccessible schema in sidebar

----

Thank you for your contribution! 
Before submitting this PR, please make sure:

- [ ] Your code builds clean without any errors or warnings
- [x] You have made the needed changes to the docs
- [x] You have written a description of what is the purpose of this pull request above
