### PR TITLE
(feat) Variables from comments

### DIFF
--- a/docs/src/pages/en/features/executing-queries.mdx
+++ b/docs/src/pages/en/features/executing-queries.mdx
@@ -69,3 +69,5 @@ ask you for it every time.
 **NOTE**: this is just a string replacement, and therefore, you can execute
 subqueries using this replacement. You can also change the query columns/filters
 itself.
+
+**TIP**: You can also set a parameters for queries at the top of the the file using `-- @var :name = '%e%'`.

--- a/docs/src/pages/en/features/executing-queries.mdx
+++ b/docs/src/pages/en/features/executing-queries.mdx
@@ -70,4 +70,4 @@ ask you for it every time.
 subqueries using this replacement. You can also change the query columns/filters
 itself.
 
-**TIP**: You can also set a parameters for queries at the top of the the file using `-- @var :name = '%e%'`.
+**TIP**: You can also set parameters for a query by preceding it with comment lines `-- @var :name = '%e%'`. Parameter values set in comments take priority over values set in the connection definition.

--- a/packages/plugins/connection-manager/extension.ts
+++ b/packages/plugins/connection-manager/extension.ts
@@ -8,7 +8,7 @@ import { EXT_CONFIG_NAMESPACE, EXT_NAMESPACE } from '@sqltools/util/constants';
 import generateId from '@sqltools/util/internal-id';
 import { default as logger, createLogger } from '@sqltools/log/src';
 import { getDataPath, SESSION_FILES_DIRNAME } from '@sqltools/util/path';
-import { extractConnName, getQueryParameters } from '@sqltools/util/query';
+import { extractConnName, getQueryParameters, extractCommentVariables } from '@sqltools/util/query';
 import { isEmpty } from '@sqltools/util/validation';
 import Context from '@sqltools/vscode/context';
 import { getOrCreateEditor, getSelectedText, readInput } from '@sqltools/vscode/utils';
@@ -220,7 +220,8 @@ export class ConnectionManagerPlugin implements IExtensionPlugin {
     const regex = Config['queryParams.regex']
     const params = getQueryParameters(query, regex);
     if (params.length > 0) {
-      const connVariables = conn.variables || {}
+      const commentVariables = extractCommentVariables(query);
+      const connVariables = { ...conn.variables || {}, ...commentVariables || {} };
       const connParams = params.filter(p => p.varName && Object.keys(connVariables).includes(p.varName))
       for (const connParam of connParams) {
         const r = new RegExp(connParam.param.replace(/([\$\[\]])/g, '\\$1'), 'g');

--- a/packages/util/query/index.ts
+++ b/packages/util/query/index.ts
@@ -55,6 +55,19 @@ export function extractConnName(query: string) {
   return ((query.match(/@conn\s*(.+)$/m) || [])[1] || '').trim() || null;
 }
 
+export function extractCommentVariables(query: string): { [key: string]: string } {
+  const variables: { [key: string]: string } = {};
+  const regex = /@var\s+(.+?)\s*=\s*(.+?)\s*$/gm;
+  
+  let match;
+  while ((match = regex.exec(query)) !== null) {
+    const [, key, value] = match;
+    variables[key] = value.trim();
+  }
+  
+  return variables;
+}
+
 export function getQueryParameters(query: string, regexStr: string) {
   if (!query || !regexStr) return [];
 


### PR DESCRIPTION
This pull request implements functionality to define variables for parameter replacement as comments above the query.

This fixes the remaining part of issue #744.

Syntax follows proposed format in #744 and mirrors existing syntax for defining connection to be used as comment above the query.

`-- @var key = value`

Example:

```
-- @var FOO = "bar"

SELECT :FOO as baz
```

- [X] Your code builds clean without any errors or warnings
- [X] You have made the needed changes to the docs
- [X] You have written a description of what is the purpose of this pull request above
