### PR TITLE
Fix SSH password authentication

### DIFF
--- a/packages/base-driver/src/index.ts
+++ b/packages/base-driver/src/index.ts
@@ -154,7 +154,8 @@ export default abstract class AbstractDriver<ConnectionType extends any, DriverO
         host: ssh.host,
         port: ssh.port,
         username: ssh.username,
-        privateKey: fs.readFileSync(ssh.privateKeyPath),
+        ...(ssh.password ? { password: ssh.password } : {}),
+        ...(ssh.privateKeyPath ? { privateKey: fs.readFileSync(ssh.privateKeyPath) } : {}),
       },
       {
         dstAddr: db.host,


### PR DESCRIPTION
## Problem

SSH tunnel connections using password authentication were failing due to two issues:

- The password parameter was not being passed to the tunnel configuration
- The code was trying to read privateKeyPath even when it was undefined, causing errors

## Testing
Verified with local Docker containers running SSH server and MySQL server.

## Issue
- https://github.com/mtxr/vscode-sqltools/issues/1518