### PR TITLE
Bump `@sqltools/base-driver` to 0.2.3

### DIFF
--- a/packages/base-driver/README.md
+++ b/packages/base-driver/README.md
@@ -12,6 +12,10 @@ Inactive icon: Opacity 50%, no margins and paddings
 
 ## Changelog
 
+### v0.2.3
+
+- Support SSH tunnel that uses password.
+
 ### v0.2.2
 
 - createSshTunnel needs to be public rather than protected.

--- a/packages/base-driver/package.json
+++ b/packages/base-driver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sqltools/base-driver",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "SQLTools Base Driver",
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
Publishes the #1519 fix so drivers can use it.