### PR TITLE
Make tunnel-ssh autoClose configurable

### DIFF
--- a/packages/base-driver/src/index.ts
+++ b/packages/base-driver/src/index.ts
@@ -17,7 +17,7 @@ import { createLogger } from '@sqltools/log';
 import path from 'path';
 import fs from 'fs';
 import { URI } from 'vscode-uri';
-import { createTunnel } from 'tunnel-ssh';
+import { createTunnel, TunnelOptions } from 'tunnel-ssh';
 import { AddressInfo } from 'net';
 
 export default abstract class AbstractDriver<ConnectionType extends any, DriverOptions extends any> implements IConnectionDriver {
@@ -142,12 +142,14 @@ export default abstract class AbstractDriver<ConnectionType extends any, DriverO
     db: {
       host: string;
       port: number;
-    }
+    },
+    tunnelOptions?: Partial<TunnelOptions>
   ) {
     const [sshTunnel] = await createTunnel(
       {
         autoClose: true,
         reconnectOnError: false,
+        ...tunnelOptions,
       },
       null,
       {
@@ -164,6 +166,9 @@ export default abstract class AbstractDriver<ConnectionType extends any, DriverO
     );
     return {
       port: (sshTunnel.address() as AddressInfo).port,
+      close: () => {
+        sshTunnel.close();
+      },
     };
   }
 


### PR DESCRIPTION
## Description

Makes the `tunnel-ssh` `autoClose` option configurable to support HTTP-based database drivers like ClickHouse.

Fixes #1529

## Changes

- Added optional `tunnelOptions` parameter to `createSshTunnel` method
- Exposed `close()` method in return value for manual tunnel control
- Default behavior unchanged (backward compatible)

## Usage

```typescript
// Custom tunnel options
const tunnel = await this.createSshTunnel(
  sshConfig,
  dbConfig,
  { autoClose: false }
);

// Manually close when needed
tunnel.close();
```

----

- [ ] Your code builds clean without any errors or warnings
- [ ] You have made the needed changes to the docs
- [ ] You have written a description of what is the purpose of this pull request above
