### PR TITLE
Add a strategy conf option allow workspace selection

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -989,7 +989,7 @@
                         "workspace"
                     ],
                     "default": "auto",
-                    "description": "SQLTools configuration strategy. 'auto' will use workspace settings if a workspace is open, and global settings otherwise. 'global' and 'workspace' will force the usage of global or workspace settings respectively."
+                    "description": "Where SQLTools will store connections you define. 'auto' will use workspace settings if a workspace is open, and global settings otherwise. 'global' and 'workspace' will force the usage of global or workspace settings respectively."
                 }
             }
         },

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -981,7 +981,7 @@
                     "description": "Display connections in two groups, 'Connected' and 'Not Connected'.",
                     "default": false
                 },
-                "sqltools.strategy": {
+                "sqltools.connectionStore": {
                     "type": "string",
                     "enum": [
                         "auto",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -980,6 +980,16 @@
                     "type": "boolean",
                     "description": "Display connections in two groups, 'Connected' and 'Not Connected'.",
                     "default": false
+                },
+                "sqltools.strategy": {
+                    "type": "string",
+                    "enum": [
+                        "auto",
+                        "global",
+                        "workspace"
+                    ],
+                    "default": "auto",
+                    "description": "SQLTools configuration strategy. 'auto' will use workspace settings if a workspace is open, and global settings otherwise. 'global' and 'workspace' will force the usage of global or workspace settings respectively."
                 }
             }
         },

--- a/packages/plugins/connection-manager/extension.ts
+++ b/packages/plugins/connection-manager/extension.ts
@@ -480,11 +480,27 @@ export class ConnectionManagerPlugin implements IExtensionPlugin {
       log.warn('Nothing to do. No parameter received');
       return;
     }
+    let target: ConfigurationTarget;
+    const strategy = Config.strategy || 'auto';
+    if (!writeTo) {
+      switch (strategy) {
+        case 'global':
+          target = ConfigurationTarget.Global;
+          break;
+        case 'workspace':
+          target = ConfigurationTarget.Workspace;
+          break;
+        default:
+          target = workspace.workspaceFolders ? ConfigurationTarget.Workspace : ConfigurationTarget.Global;
+      }
+    } else {
+      target = ConfigurationTarget[writeTo];
+    }
 
-    const connList = this.getConnectionList(ConfigurationTarget[writeTo] || undefined);
+    const connList = this.getConnectionList(target || undefined);
     this._throwIfNotUnique(connInfo, connList);
     connList.push(connInfo);
-    return this.saveConnectionList(connList, ConfigurationTarget[writeTo]);
+    return this.saveConnectionList(connList, target);
   }
 
   private ext_updateConnection = (oldId: string, connInfo: IConnection, writeTo?: keyof typeof ConfigurationTarget) => {

--- a/packages/plugins/connection-manager/extension.ts
+++ b/packages/plugins/connection-manager/extension.ts
@@ -483,7 +483,7 @@ export class ConnectionManagerPlugin implements IExtensionPlugin {
     let target: ConfigurationTarget;
     const connectionStore = Config.connectionStore || 'auto';
     if (!writeTo) {
-      switch (strategy) {
+      switch (connectionStore) {
         case 'global':
           target = ConfigurationTarget.Global;
           break;

--- a/packages/plugins/connection-manager/extension.ts
+++ b/packages/plugins/connection-manager/extension.ts
@@ -481,7 +481,7 @@ export class ConnectionManagerPlugin implements IExtensionPlugin {
       return;
     }
     let target: ConfigurationTarget;
-    const strategy = Config.strategy || 'auto';
+    const connectionStore = Config.connectionStore || 'auto';
     if (!writeTo) {
       switch (strategy) {
         case 'global':

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -832,7 +832,7 @@ export interface ISettings {
    * @default 'auto'
    * @memberof ISettings
    */
-  strategy?: 'auto' | 'global' | 'workspace';
+  connectionStore?: 'auto' | 'global' | 'workspace';
 }
 
 export interface IConfig extends ISettings {

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -823,6 +823,16 @@ export interface ISettings {
   debug?: { namespaces?: string };
 
   'connectionExplorer.groupConnected'?: boolean;
+
+  /**
+   * SQLTools configuration strategy.
+   * 'auto' will use workspace settings if a workspace is open, and global settings otherwise.
+   * 'global' and 'workspace' will force the usage of global or workspace settings respectively.
+   * @type {string}
+   * @default 'auto'
+   * @memberof ISettings
+   */
+  strategy?: 'auto' | 'global' | 'workspace';
 }
 
 export interface IConfig extends ISettings {

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -825,7 +825,7 @@ export interface ISettings {
   'connectionExplorer.groupConnected'?: boolean;
 
   /**
-   * SQLTools configuration strategy.
+   * Where SQLTools will store connections you define.
    * 'auto' will use workspace settings if a workspace is open, and global settings otherwise.
    * 'global' and 'workspace' will force the usage of global or workspace settings respectively.
    * @type {string}


### PR DESCRIPTION
Describe here what is this PR about and what we are achieving merging this.
The `sqltools` default save the db connections to `workspace`/`settings.json` based on how user open the project. But in some cases, especially for micro services, we don't want to save the db connections as shared. To solve this case, I try to add a `sqltools.strategy` option to allow user select to save db connections to User Settings JSON or keep the old pattern

----

Thank you for your contribution! 
Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] You have made the needed changes to the docs
- [x] You have written a description of what is the purpose of this pull request above
