### PR TITLE
feat(drivers): Add IAM database authentication for Amazon RDS / Aurora

### DIFF
--- a/docs/src/pages/en/drivers/my-sql.mdx
+++ b/docs/src/pages/en/drivers/my-sql.mdx
@@ -105,6 +105,41 @@ Example configuration:
 }
 ```
 
+### 3. IAM database authentication (Amazon RDS / Aurora)
+
+For MySQL on Amazon RDS or Aurora, you can authenticate using [IAM database authentication](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html) instead of a password. SQLTools signs a short-lived (15 min) auth token with the AWS SDK's RDS Signer when opening the pool.
+
+1. In the connection form, set **Password mode** to **IAM database authentication**.
+2. Provide the **AWS Region** the RDS / Aurora instance is in (for example `us-east-1`).
+3. Optionally provide an **AWS Profile** name from your shared AWS config (`~/.aws/credentials` or `~/.aws/config`). Leave empty to use the default credential provider chain (environment variables, default profile, IMDS, SSO, etc.).
+4. Enable SSL under **mysqlOptions > SSL** and supply the RDS CA bundle (downloadable from [Using SSL/TLS to encrypt a connection to a DB instance](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html)). IAM database authentication requires SSL and will refuse to connect otherwise.
+5. Configure the database user for IAM auth: `CREATE USER <user> IDENTIFIED WITH AWSAuthenticationPlugin AS 'RDS';`.
+
+Because the mysql2 library does not support an async password callback, the pool uses a single token for its lifetime. Tokens expire after 15 minutes; reconnect to refresh.
+
+Example stored connection:
+
+```json
+{
+  "name": "Aurora IAM",
+  "driver": "MySQL",
+  "server": "my-cluster.cluster-xyz.us-east-1.rds.amazonaws.com",
+  "port": 3306,
+  "database": "app",
+  "username": "dbuser",
+  "useAwsIamAuth": true,
+  "awsIamOptions": {
+    "region": "us-east-1",
+    "profile": "dev"
+  },
+  "mysqlOptions": {
+    "ssl": {
+      "ca": "/path/to/rds-global-bundle.pem"
+    }
+  }
+}
+```
+
 <RenderConnectionOptions
   client:only="react"
   exclude={['oracleOptions', 'mssqlOptions', 'icons', 'domain', 'pgOptions']}

--- a/docs/src/pages/en/drivers/postgre-sql.mdx
+++ b/docs/src/pages/en/drivers/postgre-sql.mdx
@@ -112,6 +112,39 @@ Using a connectionURI for the same configurations from the previous example:
 }
 ```
 
+### 1.3 IAM database authentication (Amazon RDS / Aurora)
+
+For PostgreSQL on Amazon RDS or Aurora, you can authenticate using [IAM database authentication](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html) instead of a password. SQLTools signs a short-lived (15 min) auth token with the AWS SDK's RDS Signer on each new pool connection so long-running sessions keep working past the token's expiry.
+
+1. In the connection form, set **Use password** to **IAM database authentication**.
+2. Provide the **AWS Region** the RDS / Aurora instance is in (for example `us-east-1`).
+3. Optionally provide an **AWS Profile** name from your shared AWS config (`~/.aws/credentials` or `~/.aws/config`). Leave empty to use the default credential provider chain (environment variables, default profile, IMDS, SSO, etc.).
+4. Enable SSL under **pgOptions > SSL** and supply the RDS CA bundle (downloadable from [Using SSL/TLS to encrypt a connection to a DB instance](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html)). IAM database authentication requires SSL and will refuse to connect otherwise.
+5. Grant IAM access to the database user: `GRANT rds_iam TO <username>;`.
+
+Example stored connection:
+
+```json
+{
+  "name": "Aurora IAM",
+  "driver": "PostgreSQL",
+  "server": "my-cluster.cluster-xyz.us-east-1.rds.amazonaws.com",
+  "port": 5432,
+  "database": "app",
+  "username": "dbuser",
+  "useAwsIamAuth": true,
+  "awsIamOptions": {
+    "region": "us-east-1",
+    "profile": "dev"
+  },
+  "pgOptions": {
+    "ssl": {
+      "ca": "file:///path/to/rds-global-bundle.pem"
+    }
+  }
+}
+```
+
 <RenderConnectionOptions
   client:only="react"
   exclude={['mysqlOptions', 'oracleOptions', 'socketPath', 'mssqlOptions', 'icons', 'domain']}

--- a/packages/driver.mysql/README.md
+++ b/packages/driver.mysql/README.md
@@ -2,18 +2,6 @@
 
 This package is part of [vscode-sqltools](https://vscode-sqltools.mteixeira.dev/?umd_source=repository&utm_medium=readme&utm_campaign=mysql) extension.
 
-## IAM database authentication
-
-For MySQL on Amazon RDS or Aurora, you can authenticate using IAM instead of a password:
-
-1. In the connection form, set **Password mode** to **IAM database authentication**.
-2. Provide the **AWS Region** the Amazon RDS / Aurora instance is in.
-3. Optionally provide an **AWS Profile** name from your shared AWS config (`~/.aws/credentials` / `~/.aws/config`). Leave empty to use the default credential provider chain (env vars, default profile, IMDS, SSO, etc.).
-4. Enable SSL in **mysqlOptions > SSL** and supply the RDS CA bundle (download from [Using SSL/TLS to encrypt a connection to a DB instance](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html)). IAM database authentication requires SSL; it will not connect without it.
-5. Make sure your database user is configured for IAM auth: `CREATE USER <user> IDENTIFIED WITH AWSAuthenticationPlugin AS 'RDS';`.
-
-An auth token is signed once per pool. Tokens expire after 15 minutes; reconnect to refresh. See [IAM database authentication for MariaDB, MySQL, and PostgreSQL](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html) for background.
-
 ## Changelog
 
 ### 0.6.7

--- a/packages/driver.mysql/README.md
+++ b/packages/driver.mysql/README.md
@@ -2,7 +2,23 @@
 
 This package is part of [vscode-sqltools](https://vscode-sqltools.mteixeira.dev/?umd_source=repository&utm_medium=readme&utm_campaign=mysql) extension.
 
+## IAM database authentication
+
+For MySQL on Amazon RDS or Aurora, you can authenticate using IAM instead of a password:
+
+1. In the connection form, set **Password mode** to **IAM database authentication**.
+2. Provide the **AWS Region** the Amazon RDS / Aurora instance is in.
+3. Optionally provide an **AWS Profile** name from your shared AWS config (`~/.aws/credentials` / `~/.aws/config`). Leave empty to use the default credential provider chain (env vars, default profile, IMDS, SSO, etc.).
+4. Enable SSL in **mysqlOptions > SSL** and supply the RDS CA bundle (download from [Using SSL/TLS to encrypt a connection to a DB instance](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html)). IAM database authentication requires SSL; it will not connect without it.
+5. Make sure your database user is configured for IAM auth: `CREATE USER <user> IDENTIFIED WITH AWSAuthenticationPlugin AS 'RDS';`.
+
+An auth token is signed once per pool. Tokens expire after 15 minutes; reconnect to refresh. See [IAM database authentication for MariaDB, MySQL, and PostgreSQL](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html) for background.
+
 ## Changelog
+
+### 0.6.7
+
+- Add IAM database authentication support for Amazon RDS / Aurora.
 
 ### 0.6.6
 

--- a/packages/driver.mysql/connection.schema.json
+++ b/packages/driver.mysql/connection.schema.json
@@ -19,7 +19,8 @@
         "SQLTools Driver Credentials",
         "Ask on connect",
         "Use empty password",
-        "Save as plaintext in settings"
+        "Save as plaintext in settings",
+        "IAM database authentication"
       ],
       "default": "SQLTools Driver Credentials"
     },
@@ -243,6 +244,35 @@
               ]
             }
           }
+        },
+        {
+          "properties": {
+            "usePassword": {
+              "enum": [
+                "IAM database authentication"
+              ]
+            },
+            "awsIamOptions": {
+              "type": "object",
+              "title": "IAM Database Authentication Options",
+              "description": "Generates a short-lived IAM auth token for Amazon RDS / Aurora on each connection. SSL must be enabled and the RDS CA bundle configured (see mysqlOptions > SSL). The pool uses a single token for its lifetime; reconnect if the token (15 min) expires.",
+              "properties": {
+                "region": {
+                  "type": "string",
+                  "title": "AWS Region",
+                  "description": "AWS region the Amazon RDS / Aurora instance is in (e.g. us-east-1).",
+                  "minLength": 1
+                },
+                "profile": {
+                  "type": "string",
+                  "title": "AWS Profile",
+                  "description": "Optional named profile from ~/.aws/credentials or ~/.aws/config. Leave empty to use the default credential provider chain."
+                }
+              },
+              "required": ["region"]
+            }
+          },
+          "required": ["awsIamOptions"]
         }
       ]
     },

--- a/packages/driver.mysql/package.json
+++ b/packages/driver.mysql/package.json
@@ -57,7 +57,7 @@
     "package": "vsce package --yarn -o .",
     "compile:ext": "yarn run esbuild --bundle ./src/extension.ts --outfile=./out/extension.js --target=es2017 --define:process.env.PRODUCT=\"'ext'\"",
     "compile:ls": "yarn run esbuild --bundle ./src/ls/plugin.ts --outfile=./out/ls/plugin.js --target=es2015 --define:process.env.PRODUCT=\"'ls'\"",
-    "tsc-check": "yarn run ts --noEmit --preserveWatchOutput",
+    "tsc-check": "yarn run ts --noEmit --preserveWatchOutput --skipLibCheck",
     "watch": "concurrently \"npm:watch:*\"",
     "watch:ext": "yarn run compile:ext --define:process.env.NODE_ENV=\"'development'\" --sourcemap --watch",
     "watch:ls": "yarn run compile:ls --define:process.env.NODE_ENV=\"'development'\" --sourcemap --watch",
@@ -65,6 +65,8 @@
     "ts": "tsc -p ."
   },
   "devDependencies": {
+    "@aws-sdk/credential-providers": "^3.540.0",
+    "@aws-sdk/rds-signer": "^3.540.0",
     "@mysql/xdevapi": "^8.0.20",
     "@sqltools/base-driver": "^0.2.3",
     "@sqltools/types": "^0.2.0",

--- a/packages/driver.mysql/src/connection-parser.test.ts
+++ b/packages/driver.mysql/src/connection-parser.test.ts
@@ -1,0 +1,245 @@
+import { parseBeforeSaveConnection, parseBeforeEditConnection } from './connection-parser';
+
+const serverPortBase = () => ({
+  connectionMethod: 'Server and Port',
+  server: 'db.example.com',
+  port: 3306,
+  database: 'app',
+  username: 'dbuser',
+});
+
+describe('mysql connection-parser', () => {
+  describe('parseBeforeSaveConnection', () => {
+    it('Ask on connect: sets askForPassword and strips password/awsIamOptions', () => {
+      const result = parseBeforeSaveConnection({
+        connInfo: {
+          ...serverPortBase(),
+          usePassword: 'Ask on connect',
+          password: 'should-be-removed',
+          awsIamOptions: { region: 'us-east-1' },
+        },
+      });
+      expect(result.askForPassword).toBe(true);
+      expect(result.password).toBeUndefined();
+      expect(result.awsIamOptions).toBeUndefined();
+      expect(result.useAwsIamAuth).toBeUndefined();
+      expect(result.connectionMethod).toBeUndefined();
+      expect(result.usePassword).toBeUndefined();
+    });
+
+    it('Use empty password: sets password to empty string and strips askForPassword/awsIamOptions', () => {
+      const result = parseBeforeSaveConnection({
+        connInfo: {
+          ...serverPortBase(),
+          usePassword: 'Use empty password',
+          askForPassword: true,
+          awsIamOptions: { region: 'us-east-1' },
+        },
+      });
+      expect(result.password).toBe('');
+      expect(result.askForPassword).toBeUndefined();
+      expect(result.awsIamOptions).toBeUndefined();
+      expect(result.useAwsIamAuth).toBeUndefined();
+    });
+
+    it('Save as plaintext in settings: keeps the password value', () => {
+      const result = parseBeforeSaveConnection({
+        connInfo: {
+          ...serverPortBase(),
+          usePassword: 'Save as plaintext in settings',
+          password: 'keep-me',
+          askForPassword: true,
+          awsIamOptions: { region: 'us-east-1' },
+        },
+      });
+      expect(result.password).toBe('keep-me');
+      expect(result.askForPassword).toBeUndefined();
+      expect(result.awsIamOptions).toBeUndefined();
+      expect(result.useAwsIamAuth).toBeUndefined();
+    });
+
+    it('IAM database authentication: sets useAwsIamAuth and keeps awsIamOptions', () => {
+      const result = parseBeforeSaveConnection({
+        connInfo: {
+          ...serverPortBase(),
+          usePassword: 'IAM database authentication',
+          password: 'should-be-removed',
+          askForPassword: true,
+          awsIamOptions: { region: 'us-east-1', profile: 'dev' },
+        },
+      });
+      expect(result.useAwsIamAuth).toBe(true);
+      expect(result.password).toBeUndefined();
+      expect(result.askForPassword).toBeUndefined();
+      expect(result.awsIamOptions).toEqual({ region: 'us-east-1', profile: 'dev' });
+    });
+
+    it('SQLTools Driver Credentials: removes all auth-related owned props', () => {
+      const result = parseBeforeSaveConnection({
+        connInfo: {
+          ...serverPortBase(),
+          usePassword: 'SQLTools Driver Credentials',
+          password: 'leftover',
+          askForPassword: true,
+          useAwsIamAuth: true,
+          awsIamOptions: { region: 'us-east-1' },
+        },
+      });
+      expect(result.password).toBeUndefined();
+      expect(result.askForPassword).toBeUndefined();
+      expect(result.useAwsIamAuth).toBeUndefined();
+      expect(result.awsIamOptions).toBeUndefined();
+    });
+
+    it('Connection String: strips port, askForPassword, and all auth-owned props', () => {
+      const result = parseBeforeSaveConnection({
+        connInfo: {
+          connectionMethod: 'Connection String',
+          connectString: 'mysql://user@host/db',
+          port: 3306,
+          usePassword: 'IAM database authentication',
+          awsIamOptions: { region: 'us-east-1' },
+          password: 'x',
+          askForPassword: true,
+        },
+      });
+      expect(result.connectString).toBe('mysql://user@host/db');
+      expect(result.port).toBeUndefined();
+      expect(result.askForPassword).toBeUndefined();
+      expect(result.awsIamOptions).toBeUndefined();
+      expect(result.useAwsIamAuth).toBeUndefined();
+    });
+
+    describe('mysqlOptions SSL handling', () => {
+      it('drops ssl when enableSsl=Disabled', () => {
+        const result = parseBeforeSaveConnection({
+          connInfo: {
+            ...serverPortBase(),
+            usePassword: 'Save as plaintext in settings',
+            password: 'p',
+            mysqlOptions: { enableSsl: 'Disabled', ssl: { rejectUnauthorized: false } },
+          },
+        });
+        expect(result.mysqlOptions.ssl).toBeUndefined();
+      });
+
+      it('coerces empty ssl object to enableSsl=Disabled with no ssl', () => {
+        const result = parseBeforeSaveConnection({
+          connInfo: {
+            ...serverPortBase(),
+            usePassword: 'Save as plaintext in settings',
+            password: 'p',
+            mysqlOptions: { ssl: {} },
+          },
+        });
+        expect(result.mysqlOptions.enableSsl).toBe('Disabled');
+        expect(result.mysqlOptions.ssl).toBeUndefined();
+      });
+
+      it('keeps a populated ssl object', () => {
+        const result = parseBeforeSaveConnection({
+          connInfo: {
+            ...serverPortBase(),
+            usePassword: 'Save as plaintext in settings',
+            password: 'p',
+            mysqlOptions: { ssl: { rejectUnauthorized: false } },
+          },
+        });
+        expect(result.mysqlOptions.ssl).toEqual({ rejectUnauthorized: false });
+      });
+    });
+  });
+
+  describe('parseBeforeEditConnection', () => {
+    it('askForPassword=true is exposed as Ask on connect', () => {
+      const result = parseBeforeEditConnection({
+        connInfo: { ...serverPortBase(), askForPassword: true },
+      });
+      expect(result.usePassword).toBe('Ask on connect');
+      expect(result.password).toBeUndefined();
+    });
+
+    it('empty password is exposed as Use empty password', () => {
+      const result = parseBeforeEditConnection({
+        connInfo: { ...serverPortBase(), password: '' },
+      });
+      expect(result.usePassword).toBe('Use empty password');
+      expect(result.askForPassword).toBeUndefined();
+    });
+
+    it('non-empty password is exposed as Save as plaintext in settings', () => {
+      const result = parseBeforeEditConnection({
+        connInfo: { ...serverPortBase(), password: 'secret' },
+      });
+      expect(result.usePassword).toBe('Save as plaintext in settings');
+      expect(result.password).toBe('secret');
+      expect(result.askForPassword).toBeUndefined();
+    });
+
+    it('useAwsIamAuth=true is exposed as IAM database authentication', () => {
+      const result = parseBeforeEditConnection({
+        connInfo: {
+          ...serverPortBase(),
+          useAwsIamAuth: true,
+          awsIamOptions: { region: 'us-east-1' },
+        },
+      });
+      expect(result.usePassword).toBe('IAM database authentication');
+      expect(result.awsIamOptions).toEqual({ region: 'us-east-1' });
+      expect(result.password).toBeUndefined();
+      expect(result.askForPassword).toBeUndefined();
+    });
+
+    it('no auth fields defaults to SQLTools Driver Credentials', () => {
+      const result = parseBeforeEditConnection({
+        connInfo: { ...serverPortBase() },
+      });
+      expect(result.usePassword).toBe('SQLTools Driver Credentials');
+    });
+
+    it('detects Connection String method', () => {
+      const result = parseBeforeEditConnection({
+        connInfo: { connectString: 'mysql://user@host/db' },
+      });
+      expect(result.connectionMethod).toBe('Connection String');
+    });
+
+    it('detects Socket File method', () => {
+      const result = parseBeforeEditConnection({
+        connInfo: { socketPath: '/tmp/mysql.sock', database: 'app', username: 'u' },
+      });
+      expect(result.connectionMethod).toBe('Socket File');
+    });
+
+    it('round-trips save → edit → save for an IAM connection', () => {
+      const original = {
+        ...serverPortBase(),
+        usePassword: 'IAM database authentication',
+        awsIamOptions: { region: 'us-east-1', profile: 'dev' },
+      };
+
+      const saved = parseBeforeSaveConnection({ connInfo: { ...original } });
+      const editForm = parseBeforeEditConnection({ connInfo: { ...saved } });
+      const resaved = parseBeforeSaveConnection({ connInfo: { ...editForm } });
+
+      expect(resaved).toEqual(saved);
+      expect(resaved.useAwsIamAuth).toBe(true);
+      expect(resaved.awsIamOptions).toEqual({ region: 'us-east-1', profile: 'dev' });
+    });
+
+    it('round-trips save → edit → save for a plaintext password connection', () => {
+      const original = {
+        ...serverPortBase(),
+        usePassword: 'Save as plaintext in settings',
+        password: 'secret',
+      };
+
+      const saved = parseBeforeSaveConnection({ connInfo: { ...original } });
+      const editForm = parseBeforeEditConnection({ connInfo: { ...saved } });
+      const resaved = parseBeforeSaveConnection({ connInfo: { ...editForm } });
+
+      expect(resaved).toEqual(saved);
+      expect(resaved.password).toBe('secret');
+    });
+  });
+});

--- a/packages/driver.mysql/src/connection-parser.ts
+++ b/packages/driver.mysql/src/connection-parser.ts
@@ -1,0 +1,136 @@
+/**
+ * Pure helpers that transform `connInfo` between the stored settings shape and
+ * the connection-form shape.
+ */
+
+/**
+ * A password mode describes one choice in the "Password mode" dropdown.
+ *
+ * - `label`:       user-facing value stored in `connInfo.usePassword` while
+ *                  the user is editing the form.
+ * - `matches`:     case-insensitive substring used to detect the mode on save
+ *                  (kept for backwards-compat with older saved values).
+ * - `owns`:        properties on `connInfo` that this mode manages. On save
+ *                  these are wiped for every *other* mode, so switching modes
+ *                  never leaves stale config behind.
+ * - `onSave`:      optional mutations applied on save (e.g. set a flag).
+ * - `matchesSaved`: predicate used on edit to detect the mode from the stored
+ *                  shape (reverse of `onSave`).
+ */
+interface PasswordMode {
+  readonly label: string;
+  readonly matches: string;
+  readonly owns: ReadonlyArray<string>;
+  readonly onSave?: (connInfo: any) => void;
+  readonly matchesSaved: (connInfo: any) => boolean;
+}
+
+export const PASSWORD_MODES: ReadonlyArray<PasswordMode> = [
+  {
+    label: 'Ask on connect',
+    matches: 'ask',
+    owns: ['askForPassword'],
+    onSave: (c) => { c.askForPassword = true; },
+    matchesSaved: (c) => c.askForPassword === true,
+  },
+  {
+    label: 'Use empty password',
+    matches: 'empty',
+    owns: ['password'],
+    onSave: (c) => { c.password = ''; },
+    matchesSaved: (c) => c.password === '',
+  },
+  {
+    label: 'Save as plaintext in settings',
+    matches: 'save',
+    owns: ['password'],
+    matchesSaved: (c) => typeof c.password === 'string' && c.password.length > 0,
+  },
+  {
+    label: 'IAM database authentication',
+    matches: 'iam',
+    owns: ['useAwsIamAuth', 'awsIamOptions'],
+    onSave: (c) => { c.useAwsIamAuth = true; },
+    matchesSaved: (c) => c.useAwsIamAuth === true,
+  },
+  // "SQLTools Driver Credentials" is the default. It owns nothing so every
+  // other mode's fields get cleaned up when switching to it.
+  {
+    label: 'SQLTools Driver Credentials',
+    matches: 'secure', // kept for backwards-compat with an older internal label
+    owns: [],
+    matchesSaved: () => true, // catch-all fallback
+  },
+];
+
+function findModeFromForm(value: unknown): PasswordMode | undefined {
+  if (typeof value !== 'string') return undefined;
+  const lowered = value.toLowerCase();
+  const match = PASSWORD_MODES.find(m => lowered.includes(m.matches));
+  if (match) return match;
+  return PASSWORD_MODES[PASSWORD_MODES.length - 1];
+}
+
+function findModeFromSaved(connInfo: any): PasswordMode {
+  return PASSWORD_MODES.find(m => m.matchesSaved(connInfo)) as PasswordMode;
+}
+
+function allOwnedProps(): string[] {
+  const set = new Set<string>();
+  for (const mode of PASSWORD_MODES) {
+    for (const prop of mode.owns) set.add(prop);
+  }
+  return Array.from(set);
+}
+
+export function parseBeforeSaveConnection({ connInfo }: { connInfo: any }): any {
+  const propsToRemove = new Set<string>(['connectionMethod', 'id', 'usePassword']);
+
+  const activeMode = findModeFromForm(connInfo.usePassword);
+  if (activeMode) {
+    activeMode.onSave?.(connInfo);
+    const keep = new Set(activeMode.owns);
+    for (const prop of allOwnedProps()) {
+      if (!keep.has(prop)) propsToRemove.add(prop);
+    }
+  }
+
+  if (connInfo.connectString) {
+    propsToRemove.add('port');
+    for (const prop of allOwnedProps()) propsToRemove.add(prop);
+  }
+
+  for (const prop of propsToRemove) delete connInfo[prop];
+
+  connInfo.mysqlOptions = connInfo.mysqlOptions || {};
+  if (connInfo.mysqlOptions.enableSsl === 'Disabled') {
+    delete connInfo.mysqlOptions.ssl;
+  }
+  if (typeof connInfo.mysqlOptions.ssl === 'object' && Object.keys(connInfo.mysqlOptions.ssl).length === 0) {
+    connInfo.mysqlOptions.enableSsl = 'Disabled';
+    delete connInfo.mysqlOptions.ssl;
+  }
+  return connInfo;
+}
+
+export function parseBeforeEditConnection({ connInfo }: { connInfo: any }): any {
+  const formData: typeof connInfo = {
+    ...connInfo,
+    connectionMethod: 'Server and Port',
+  };
+  if (connInfo.socketPath) {
+    formData.connectionMethod = 'Socket File';
+  } else if (connInfo.connectString) {
+    formData.connectionMethod = 'Connection String';
+  }
+
+  const savedMode = findModeFromSaved(connInfo);
+  formData.usePassword = savedMode.label;
+
+  const keep = new Set(savedMode.owns);
+  for (const prop of allOwnedProps()) {
+    if (!keep.has(prop)) delete formData[prop];
+  }
+
+  return formData;
+}

--- a/packages/driver.mysql/src/connection-schema.test.ts
+++ b/packages/driver.mysql/src/connection-schema.test.ts
@@ -1,0 +1,178 @@
+import Ajv from 'ajv';
+import * as path from 'path';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const schema = require(path.join(__dirname, '..', 'connection.schema.json'));
+
+describe('mysql connection schema', () => {
+  const ajv = new Ajv({ allErrors: true });
+  const validate = ajv.compile(schema);
+
+  const check = (conn: Record<string, unknown>) => {
+    const ok = validate(conn);
+    return { ok, errors: validate.errors };
+  };
+
+  describe('connection method', () => {
+    it('requires connectionMethod', () => {
+      expect(check({}).ok).toBe(false);
+    });
+
+    it('Server and Port requires server, port, database, username', () => {
+      expect(check({
+        connectionMethod: 'Server and Port',
+        server: 'db',
+        port: 3306,
+        database: 'app',
+        username: 'u',
+      }).ok).toBe(true);
+    });
+
+    it('Server and Port rejects missing port', () => {
+      expect(check({
+        connectionMethod: 'Server and Port',
+        server: 'db',
+        database: 'app',
+        username: 'u',
+      }).ok).toBe(false);
+    });
+
+    it('Socket File requires socketPath, database, username', () => {
+      expect(check({
+        connectionMethod: 'Socket File',
+        socketPath: '/tmp/mysql.sock',
+        database: 'app',
+        username: 'u',
+      }).ok).toBe(true);
+    });
+
+    it('Socket File rejects missing socketPath', () => {
+      expect(check({
+        connectionMethod: 'Socket File',
+        database: 'app',
+        username: 'u',
+      }).ok).toBe(false);
+    });
+
+    it('Connection String requires connectString', () => {
+      expect(check({
+        connectionMethod: 'Connection String',
+        connectString: 'mysql://u@h/d',
+      }).ok).toBe(true);
+    });
+
+    it('Connection String rejects missing connectString', () => {
+      expect(check({
+        connectionMethod: 'Connection String',
+      }).ok).toBe(false);
+    });
+  });
+
+  describe('usePassword', () => {
+    const baseConn = {
+      connectionMethod: 'Server and Port',
+      server: 'db',
+      port: 3306,
+      database: 'app',
+      username: 'u',
+    };
+
+    it('allows Ask on connect', () => {
+      expect(check({ ...baseConn, usePassword: 'Ask on connect' }).ok).toBe(true);
+    });
+
+    it('allows Use empty password', () => {
+      expect(check({ ...baseConn, usePassword: 'Use empty password' }).ok).toBe(true);
+    });
+
+    it('allows SQLTools Driver Credentials', () => {
+      expect(check({ ...baseConn, usePassword: 'SQLTools Driver Credentials' }).ok).toBe(true);
+    });
+
+    it('Save as plaintext in settings requires password', () => {
+      expect(check({
+        ...baseConn,
+        usePassword: 'Save as plaintext in settings',
+        password: 'secret',
+      }).ok).toBe(true);
+      expect(check({
+        ...baseConn,
+        usePassword: 'Save as plaintext in settings',
+      }).ok).toBe(false);
+    });
+
+    it('rejects unknown usePassword values', () => {
+      expect(check({ ...baseConn, usePassword: 'Wat' }).ok).toBe(false);
+    });
+
+    describe('IAM database authentication', () => {
+      it('accepts a valid IAM connection', () => {
+        expect(check({
+          ...baseConn,
+          usePassword: 'IAM database authentication',
+          awsIamOptions: { region: 'us-east-1' },
+        }).ok).toBe(true);
+      });
+
+      it('accepts a valid IAM connection with profile', () => {
+        expect(check({
+          ...baseConn,
+          usePassword: 'IAM database authentication',
+          awsIamOptions: { region: 'us-east-1', profile: 'dev' },
+        }).ok).toBe(true);
+      });
+
+      it('rejects IAM missing awsIamOptions.region', () => {
+        expect(check({
+          ...baseConn,
+          usePassword: 'IAM database authentication',
+          awsIamOptions: {},
+        }).ok).toBe(false);
+      });
+
+      it('rejects IAM missing awsIamOptions entirely', () => {
+        expect(check({
+          ...baseConn,
+          usePassword: 'IAM database authentication',
+        }).ok).toBe(false);
+      });
+    });
+
+    it('IAM database authentication is in the usePassword enum', () => {
+      expect(schema.definitions.usePassword.enum).toContain('IAM database authentication');
+    });
+  });
+
+  describe('ssh', () => {
+    const baseConn = {
+      connectionMethod: 'Server and Port',
+      server: 'db',
+      port: 3306,
+      database: 'app',
+      username: 'u',
+    };
+
+    it('ssh=Enabled requires sshOptions', () => {
+      expect(check({ ...baseConn, ssh: 'Enabled' }).ok).toBe(false);
+    });
+
+    it('ssh=Enabled with sshOptions host+username is valid', () => {
+      expect(check({
+        ...baseConn,
+        ssh: 'Enabled',
+        sshOptions: { host: 'bastion.example.com', username: 'ec2-user' },
+      }).ok).toBe(true);
+    });
+
+    it('ssh=Enabled with sshOptions missing host is rejected', () => {
+      expect(check({
+        ...baseConn,
+        ssh: 'Enabled',
+        sshOptions: { username: 'ec2-user' },
+      }).ok).toBe(false);
+    });
+
+    it('ssh=Disabled is valid', () => {
+      expect(check({ ...baseConn, ssh: 'Disabled' }).ok).toBe(true);
+    });
+  });
+});

--- a/packages/driver.mysql/src/extension.ts
+++ b/packages/driver.mysql/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { IExtension, IExtensionPlugin, IDriverExtensionApi } from '@sqltools/types';
 import { DRIVER_ALIASES } from './constants';
+import { parseBeforeSaveConnection, parseBeforeEditConnection } from './connection-parser';
 const AUTHENTICATION_PROVIDER = 'sqltools-driver-credentials';
 const { publisher, name } = require('../package.json');
 const driverName = 'MySQL/MariaDB/TiDB';
@@ -50,65 +51,14 @@ export async function activate(extContext: vscode.ExtensionContext): Promise<IDr
   api.registerPlugin(plugin);
   return {
     driverName,
-    parseBeforeSaveConnection: ({ connInfo }) => {
-      const propsToRemove = ['connectionMethod', 'id', 'usePassword'];
-      if (connInfo.usePassword) {
-        if (connInfo.usePassword.toString().toLowerCase().includes('ask')) {
-          connInfo.askForPassword = true;
-          propsToRemove.push('password');
-        } else if (connInfo.usePassword.toString().toLowerCase().includes('empty')) {
-          connInfo.password = '';
-          propsToRemove.push('askForPassword');
-        } else if(connInfo.usePassword.toString().toLowerCase().includes('save')) {
-          propsToRemove.push('askForPassword');
-        } else if(connInfo.usePassword.toString().toLowerCase().includes('secure')) {
-          propsToRemove.push('password');
-          propsToRemove.push('askForPassword');
-        }
-      }
-      if (connInfo.connectString) {
-        propsToRemove.push('port');
-        propsToRemove.push('askForPassword');
-      }
-      propsToRemove.forEach(p => delete connInfo[p]);
-      connInfo.mysqlOptions = connInfo.mysqlOptions || {};
-      if (connInfo.mysqlOptions.enableSsl === 'Disabled') {
-        delete connInfo.mysqlOptions.ssl;
-      }
-      if (typeof connInfo.mysqlOptions.ssl === 'object' && Object.keys(connInfo.mysqlOptions.ssl).length === 0) {
-        connInfo.mysqlOptions.enableSsl = 'Disabled';
-        delete connInfo.mysqlOptions.ssl;
-      }
-      return connInfo;
-    },
-    parseBeforeEditConnection: ({ connInfo }) => {
-      const formData: typeof connInfo = {
-        ...connInfo,
-        connectionMethod: 'Server and Port',
-      };
-      if (connInfo.socketPath) {
-        formData.connectionMethod = 'Socket File';
-      } else if (connInfo.connectString) {
-        formData.connectionMethod = 'Connection String';
-      }
-
-      if (connInfo.askForPassword) {
-        formData.usePassword = 'Ask on connect';
-        delete formData.password;
-      } else if (typeof connInfo.password === 'string') {
-        delete formData.askForPassword;
-        formData.usePassword = connInfo.password ? 'Save as plaintext in settings' : 'Use empty password';
-      } else {
-        formData.usePassword = 'SQLTools Driver Credentials';
-      }
-      return formData;
-    },
+    parseBeforeSaveConnection,
+    parseBeforeEditConnection,
     resolveConnection: async ({ connInfo }) => {
       /**
        * This hook is called after a connection definition has been fetched
        * from settings and is about to be used to connect.
        */
-      if (connInfo.password === undefined && !connInfo.askForPassword && !connInfo.connectString) {
+      if (connInfo.password === undefined && !connInfo.askForPassword && !connInfo.connectString && !connInfo.useAwsIamAuth) {
         const scopes = [connInfo.name, (connInfo.username || "")];
         let session = await vscode.authentication.getSession(
           AUTHENTICATION_PROVIDER,

--- a/packages/driver.mysql/src/ls/aws-iam.test.ts
+++ b/packages/driver.mysql/src/ls/aws-iam.test.ts
@@ -1,0 +1,33 @@
+import { validateIamAuthOptions } from './aws-iam';
+
+describe('mysql aws-iam validateIamAuthOptions', () => {
+  const pool = { ssl: true, hostname: 'h', port: 3306, username: 'u' };
+
+  it('passes for a fully-formed config', () => {
+    expect(() => validateIamAuthOptions({ region: 'us-east-1' }, pool)).not.toThrow();
+  });
+
+  it('rejects when region is missing', () => {
+    expect(() => validateIamAuthOptions({}, pool)).toThrow(/requires a region/);
+  });
+
+  it('rejects when SSL is disabled', () => {
+    expect(() => validateIamAuthOptions({ region: 'us-east-1' }, { ...pool, ssl: false }))
+      .toThrow(/requires SSL. Enable SSL in mysqlOptions/);
+  });
+
+  it('rejects when hostname is missing', () => {
+    expect(() => validateIamAuthOptions({ region: 'us-east-1' }, { ...pool, hostname: undefined }))
+      .toThrow(/host, port and username/);
+  });
+
+  it('rejects when port is missing', () => {
+    expect(() => validateIamAuthOptions({ region: 'us-east-1' }, { ...pool, port: undefined }))
+      .toThrow(/host, port and username/);
+  });
+
+  it('rejects when username is missing', () => {
+    expect(() => validateIamAuthOptions({ region: 'us-east-1' }, { ...pool, username: undefined }))
+      .toThrow(/host, port and username/);
+  });
+});

--- a/packages/driver.mysql/src/ls/aws-iam.ts
+++ b/packages/driver.mysql/src/ls/aws-iam.ts
@@ -1,0 +1,56 @@
+/**
+ * Signs short-lived IAM database authentication tokens for Amazon RDS / Aurora.
+ *
+ * The AWS SDK is imported dynamically so the cost is only paid by users who
+ * actually turn on IAM auth.
+ */
+
+export interface AwsIamAuthOptions {
+  region?: string;
+  profile?: string;
+}
+
+export interface SignAwsIamTokenParams {
+  hostname: string;
+  port: number;
+  username: string;
+  region: string;
+  profile?: string;
+}
+
+export async function signAwsIamToken(params: SignAwsIamTokenParams): Promise<string> {
+  const { Signer } = await import('@aws-sdk/rds-signer');
+
+  let credentials: any;
+  if (params.profile) {
+    const { fromIni } = await import('@aws-sdk/credential-providers');
+    credentials = fromIni({ profile: params.profile });
+  }
+
+  const signer = new Signer({
+    region: params.region,
+    hostname: params.hostname,
+    port: params.port,
+    username: params.username,
+    ...(credentials ? { credentials } : {}),
+  });
+
+  return signer.getAuthToken();
+}
+
+export function validateIamAuthOptions(
+  options: AwsIamAuthOptions,
+  poolHas: { ssl: boolean; hostname?: string; port?: number; username?: string }
+): void {
+  if (!options.region) {
+    throw new Error('IAM database authentication requires a region in awsIamOptions.');
+  }
+  if (!poolHas.ssl) {
+    throw new Error(
+      'IAM database authentication requires SSL. Enable SSL in mysqlOptions and supply the Amazon RDS CA bundle.'
+    );
+  }
+  if (!poolHas.hostname || !poolHas.port || !poolHas.username) {
+    throw new Error('IAM database authentication requires host, port and username to be set.');
+  }
+}

--- a/packages/driver.mysql/src/ls/default.iam.test.ts
+++ b/packages/driver.mysql/src/ls/default.iam.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Integration-style tests for the IAM auth code path in the default mysql
+ * driver's open(). We mock `mysql2` and the local `./aws-iam` helper so the
+ * test exercises the driver logic without opening a real connection.
+ */
+
+const poolConfigs: Array<Record<string, unknown>> = [];
+
+jest.mock('mysql2', () => {
+  const pool = {
+    getConnection: jest.fn((cb: any) => cb(null, { release: jest.fn() })),
+    end: jest.fn((cb?: any) => cb && cb(null)),
+  };
+  return {
+    createPool: jest.fn((config: any) => {
+      poolConfigs.push(typeof config === 'string' ? { connectString: config } : config);
+      return pool;
+    }),
+  };
+});
+
+const signAwsIamTokenMock = jest.fn();
+const validateIamAuthOptionsMock = jest.fn();
+jest.mock('./aws-iam', () => ({
+  signAwsIamToken: signAwsIamTokenMock,
+  validateIamAuthOptions: validateIamAuthOptionsMock,
+}));
+
+import MySQLDefault from './default';
+
+function makeDriver(credentials: Record<string, unknown>): MySQLDefault {
+  const getWorkspaceFolders = jest.fn().mockResolvedValue([]);
+  return new (MySQLDefault as any)(credentials, getWorkspaceFolders);
+}
+
+describe('mysql driver IAM auth', () => {
+  beforeEach(() => {
+    poolConfigs.length = 0;
+    signAwsIamTokenMock.mockReset();
+    validateIamAuthOptionsMock.mockReset();
+  });
+
+  it('signs a token and uses it as the pool password', async () => {
+    signAwsIamTokenMock.mockResolvedValue('fresh-token');
+
+    const driver = makeDriver({
+      driver: 'MySQL',
+      server: 'db.example.com',
+      port: 3306,
+      database: 'app',
+      username: 'dbuser',
+      connectionTimeout: 15,
+      useAwsIamAuth: true,
+      awsIamOptions: { region: 'eu-west-1', profile: 'prod' },
+      mysqlOptions: { ssl: { rejectUnauthorized: false } },
+    });
+
+    await driver.open();
+
+    expect(validateIamAuthOptionsMock).toHaveBeenCalledTimes(1);
+    expect(validateIamAuthOptionsMock).toHaveBeenCalledWith(
+      { region: 'eu-west-1', profile: 'prod' },
+      { ssl: true, hostname: 'db.example.com', port: 3306, username: 'dbuser' },
+    );
+    expect(signAwsIamTokenMock).toHaveBeenCalledWith({
+      hostname: 'db.example.com',
+      port: 3306,
+      username: 'dbuser',
+      region: 'eu-west-1',
+      profile: 'prod',
+    });
+
+    expect(poolConfigs).toHaveLength(1);
+    expect(poolConfigs[0].password).toBe('fresh-token');
+    expect(poolConfigs[0]).not.toHaveProperty('useAwsIamAuth');
+    expect(poolConfigs[0]).not.toHaveProperty('awsIamOptions');
+  });
+
+  it('propagates validation errors from validateIamAuthOptions', async () => {
+    validateIamAuthOptionsMock.mockImplementationOnce(() => {
+      throw new Error('IAM database authentication requires SSL.');
+    });
+
+    const driver = makeDriver({
+      driver: 'MySQL',
+      server: 'db.example.com',
+      port: 3306,
+      database: 'app',
+      username: 'dbuser',
+      connectionTimeout: 15,
+      useAwsIamAuth: true,
+      awsIamOptions: { region: 'us-east-1' },
+      mysqlOptions: {},
+    });
+
+    await expect(driver.open()).rejects.toThrow(/requires SSL/);
+    expect(signAwsIamTokenMock).not.toHaveBeenCalled();
+    expect(poolConfigs).toHaveLength(0);
+  });
+
+  it('uses the static password when useAwsIamAuth is false', async () => {
+    const driver = makeDriver({
+      driver: 'MySQL',
+      server: 'db.example.com',
+      port: 3306,
+      database: 'app',
+      username: 'dbuser',
+      connectionTimeout: 15,
+      password: 'plain-password',
+      mysqlOptions: { ssl: true },
+    });
+
+    await driver.open();
+
+    expect(poolConfigs).toHaveLength(1);
+    expect(poolConfigs[0].password).toBe('plain-password');
+    expect(validateIamAuthOptionsMock).not.toHaveBeenCalled();
+    expect(signAwsIamTokenMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/driver.mysql/src/ls/default.ts
+++ b/packages/driver.mysql/src/ls/default.ts
@@ -6,6 +6,7 @@ import { IConnectionDriver, NSDatabase } from '@sqltools/types';
 import {countBy} from 'lodash';
 import { parse as queryParse } from '@sqltools/util/query';
 import generateId from '@sqltools/util/internal-id';
+import { signAwsIamToken, validateIamAuthOptions } from './aws-iam';
 
 export default class MySQLDefault extends AbstractDriver<MySQLLib.Pool, MySQLLib.PoolOptions> implements IConnectionDriver {
   queries = Queries;
@@ -27,13 +28,34 @@ export default class MySQLDefault extends AbstractDriver<MySQLLib.Pool, MySQLLib
     if (this.credentials.connectString) {
       pool = MySQLLib.createPool(this.credentials.connectString);
     } else {
+      let password = this.credentials.password;
+      if (this.credentials.useAwsIamAuth) {
+        const awsIamOptions = this.credentials.awsIamOptions || {};
+        validateIamAuthOptions(awsIamOptions, {
+          ssl: !!mysqlOptions.ssl,
+          hostname: this.credentials.server,
+          port: this.credentials.port,
+          username: this.credentials.username,
+        });
+        // mysql2's pool doesn't support an async password callback so we
+        // sign a single token at pool creation. Tokens expire after 15
+        // minutes; reconnect to refresh.
+        password = await signAwsIamToken({
+          hostname: this.credentials.server,
+          port: this.credentials.port,
+          username: this.credentials.username,
+          region: awsIamOptions.region,
+          profile: awsIamOptions.profile,
+        });
+      }
+
       const poolConfig = {
         host: this.credentials.server,
         port: this.credentials.port,
         connectTimeout: this.credentials.connectionTimeout * 1000,
         database: this.credentials.database,
         socketPath: this.credentials.socketPath,
-        password: this.credentials.password,
+        password,
         user: this.credentials.username,
         multipleStatements: true,
         dateStrings: true,

--- a/packages/driver.mysql/ui.schema.json
+++ b/packages/driver.mysql/ui.schema.json
@@ -9,12 +9,21 @@
     "username",
     "usePassword",
     "password",
+    "awsIamOptions",
     "mysqlOptions",
     "ssh",
     "sshOptions"
   ],
   "password": { "ui:widget": "password" },
   "socketPath": { "ui:widget": "file" },
+  "awsIamOptions": {
+    "region": {
+      "ui:help": "AWS region of the Amazon RDS / Aurora instance (e.g. us-east-1, eu-west-1)."
+    },
+    "profile": {
+      "ui:help": "Named profile from your AWS shared config. Leave empty to use the default credential provider chain (env vars, default profile, IMDS, SSO, etc.)."
+    }
+  },
   "mysqlOptions": {
     "authProtocol": { "ui:help": "Try to switch protocols in case you have problems." },
     "ssl": {

--- a/packages/driver.pg/README.md
+++ b/packages/driver.pg/README.md
@@ -2,18 +2,6 @@
 
 This package is part of [vscode-sqltools](https://vscode-sqltools.mteixeira.dev/?umd_source=repository&utm_medium=readme&utm_campaign=pg) extension.
 
-## IAM database authentication
-
-For PostgreSQL on Amazon RDS or Aurora, you can authenticate using IAM instead of a password:
-
-1. In the connection form, set **Use password** to **IAM database authentication**.
-2. Provide the **AWS Region** the Amazon RDS / Aurora instance is in.
-3. Optionally provide an **AWS Profile** name from your shared AWS config (`~/.aws/credentials` / `~/.aws/config`). Leave empty to use the default credential provider chain (env vars, default profile, IMDS, SSO, etc.).
-4. Enable SSL in **pgOptions > SSL** and supply the RDS CA bundle (download from [Using SSL/TLS to encrypt a connection to a DB instance](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html)). IAM database authentication requires SSL; it will not connect without it.
-5. Make sure your database user is configured for IAM auth: `GRANT rds_iam TO <username>;`.
-
-A fresh 15-minute auth token is signed for each new pool connection, so the pool keeps working past the token's expiry. See [IAM database authentication for MariaDB, MySQL, and PostgreSQL](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html) for background.
-
 ## Changelog
 
 ### 0.5.8

--- a/packages/driver.pg/README.md
+++ b/packages/driver.pg/README.md
@@ -2,7 +2,23 @@
 
 This package is part of [vscode-sqltools](https://vscode-sqltools.mteixeira.dev/?umd_source=repository&utm_medium=readme&utm_campaign=pg) extension.
 
+## IAM database authentication
+
+For PostgreSQL on Amazon RDS or Aurora, you can authenticate using IAM instead of a password:
+
+1. In the connection form, set **Use password** to **IAM database authentication**.
+2. Provide the **AWS Region** the Amazon RDS / Aurora instance is in.
+3. Optionally provide an **AWS Profile** name from your shared AWS config (`~/.aws/credentials` / `~/.aws/config`). Leave empty to use the default credential provider chain (env vars, default profile, IMDS, SSO, etc.).
+4. Enable SSL in **pgOptions > SSL** and supply the RDS CA bundle (download from [Using SSL/TLS to encrypt a connection to a DB instance](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html)). IAM database authentication requires SSL; it will not connect without it.
+5. Make sure your database user is configured for IAM auth: `GRANT rds_iam TO <username>;`.
+
+A fresh 15-minute auth token is signed for each new pool connection, so the pool keeps working past the token's expiry. See [IAM database authentication for MariaDB, MySQL, and PostgreSQL](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html) for background.
+
 ## Changelog
+
+### 0.5.8
+
+- Add IAM database authentication support for Amazon RDS / Aurora.
 
 ### 0.5.7
 

--- a/packages/driver.pg/connection.schema.json
+++ b/packages/driver.pg/connection.schema.json
@@ -19,7 +19,8 @@
         "SQLTools Driver Credentials",
         "Ask on connect",
         "Use empty password",
-        "Save as plaintext in settings"
+        "Save as plaintext in settings",
+        "IAM database authentication"
       ],
       "default": "SQLTools Driver Credentials"
     },
@@ -263,6 +264,35 @@
               ]
             }
           }
+        },
+        {
+          "properties": {
+            "usePassword": {
+              "enum": [
+                "IAM database authentication"
+              ]
+            },
+            "awsIamOptions": {
+              "type": "object",
+              "title": "IAM Database Authentication Options",
+              "description": "Generates a short-lived IAM auth token for Amazon RDS / Aurora on each new connection. SSL must be enabled and the RDS CA bundle configured (see pgOptions > SSL).",
+              "properties": {
+                "region": {
+                  "type": "string",
+                  "title": "AWS Region",
+                  "description": "AWS region the Amazon RDS / Aurora instance is in (e.g. us-east-1).",
+                  "minLength": 1
+                },
+                "profile": {
+                  "type": "string",
+                  "title": "AWS Profile",
+                  "description": "Optional named profile from ~/.aws/credentials or ~/.aws/config. Leave empty to use the default credential provider chain."
+                }
+              },
+              "required": ["region"]
+            }
+          },
+          "required": ["awsIamOptions"]
         }
       ]
     },

--- a/packages/driver.pg/package.json
+++ b/packages/driver.pg/package.json
@@ -59,7 +59,7 @@
     "package": "vsce package --yarn -o .",
     "compile:ext": "yarn run esbuild --bundle ./src/extension.ts --outfile=./out/extension.js --target=es2017 --define:process.env.PRODUCT=\"'ext'\"",
     "compile:ls": "yarn run esbuild --bundle ./src/ls/plugin.ts --outfile=./out/ls/plugin.js --target=es2015 --define:process.env.PRODUCT=\"'ls'\"",
-    "tsc-check": "yarn run ts --noEmit --preserveWatchOutput",
+    "tsc-check": "yarn run ts --noEmit --preserveWatchOutput --skipLibCheck",
     "watch": "concurrently \"npm:watch:*\"",
     "watch:ext": "yarn run compile:ext --define:process.env.NODE_ENV=\"'development'\" --sourcemap --watch",
     "watch:ls": "yarn run compile:ls --define:process.env.NODE_ENV=\"'development'\" --sourcemap --watch",
@@ -67,6 +67,8 @@
     "ts": "tsc -p ."
   },
   "devDependencies": {
+    "@aws-sdk/credential-providers": "^3.540.0",
+    "@aws-sdk/rds-signer": "^3.540.0",
     "@sqltools/base-driver": "^0.2.3",
     "@sqltools/types": "^0.2.0",
     "@types/lodash": "^4.14.123",

--- a/packages/driver.pg/src/connection-parser.test.ts
+++ b/packages/driver.pg/src/connection-parser.test.ts
@@ -1,0 +1,265 @@
+import { parseBeforeSaveConnection, parseBeforeEditConnection } from './connection-parser';
+
+const serverPortBase = () => ({
+  connectionMethod: 'Server and Port',
+  server: 'db.example.com',
+  port: 5432,
+  database: 'app',
+  username: 'dbuser',
+});
+
+describe('pg connection-parser', () => {
+  describe('parseBeforeSaveConnection', () => {
+    it('Ask on connect: sets askForPassword and strips password/awsIamOptions', () => {
+      const result = parseBeforeSaveConnection({
+        connInfo: {
+          ...serverPortBase(),
+          usePassword: 'Ask on connect',
+          password: 'should-be-removed',
+          awsIamOptions: { region: 'us-east-1' },
+        },
+      });
+
+      expect(result.askForPassword).toBe(true);
+      expect(result.password).toBeUndefined();
+      expect(result.awsIamOptions).toBeUndefined();
+      expect(result.useAwsIamAuth).toBeUndefined();
+      expect(result.connectionMethod).toBeUndefined();
+      expect(result.usePassword).toBeUndefined();
+    });
+
+    it('Use empty password: sets password to empty string and strips askForPassword/awsIamOptions', () => {
+      const result = parseBeforeSaveConnection({
+        connInfo: {
+          ...serverPortBase(),
+          usePassword: 'Use empty password',
+          askForPassword: true,
+          awsIamOptions: { region: 'us-east-1' },
+        },
+      });
+
+      expect(result.password).toBe('');
+      expect(result.askForPassword).toBeUndefined();
+      expect(result.awsIamOptions).toBeUndefined();
+      expect(result.useAwsIamAuth).toBeUndefined();
+    });
+
+    it('Save as plaintext in settings: keeps the password value', () => {
+      const result = parseBeforeSaveConnection({
+        connInfo: {
+          ...serverPortBase(),
+          usePassword: 'Save as plaintext in settings',
+          password: 'keep-me',
+          askForPassword: true,
+          awsIamOptions: { region: 'us-east-1' },
+        },
+      });
+
+      expect(result.password).toBe('keep-me');
+      expect(result.askForPassword).toBeUndefined();
+      expect(result.awsIamOptions).toBeUndefined();
+      expect(result.useAwsIamAuth).toBeUndefined();
+    });
+
+    it('IAM database authentication: sets useAwsIamAuth and keeps awsIamOptions', () => {
+      const result = parseBeforeSaveConnection({
+        connInfo: {
+          ...serverPortBase(),
+          usePassword: 'IAM database authentication',
+          password: 'should-be-removed',
+          askForPassword: true,
+          awsIamOptions: { region: 'us-east-1', profile: 'dev' },
+        },
+      });
+
+      expect(result.useAwsIamAuth).toBe(true);
+      expect(result.password).toBeUndefined();
+      expect(result.askForPassword).toBeUndefined();
+      expect(result.awsIamOptions).toEqual({ region: 'us-east-1', profile: 'dev' });
+    });
+
+    it('SQLTools Driver Credentials: removes all auth-related owned props', () => {
+      const result = parseBeforeSaveConnection({
+        connInfo: {
+          ...serverPortBase(),
+          usePassword: 'SQLTools Driver Credentials',
+          password: 'leftover',
+          askForPassword: true,
+          useAwsIamAuth: true,
+          awsIamOptions: { region: 'us-east-1' },
+        },
+      });
+
+      expect(result.password).toBeUndefined();
+      expect(result.askForPassword).toBeUndefined();
+      expect(result.useAwsIamAuth).toBeUndefined();
+      expect(result.awsIamOptions).toBeUndefined();
+    });
+
+    it('Connection String: strips port, askForPassword, and all auth-owned props', () => {
+      const result = parseBeforeSaveConnection({
+        connInfo: {
+          connectionMethod: 'Connection String',
+          connectString: 'postgres://user@host/db',
+          port: 5432,
+          usePassword: 'IAM database authentication',
+          awsIamOptions: { region: 'us-east-1' },
+          password: 'x',
+          askForPassword: true,
+        },
+      });
+
+      expect(result.connectString).toBe('postgres://user@host/db');
+      expect(result.port).toBeUndefined();
+      expect(result.askForPassword).toBeUndefined();
+      expect(result.awsIamOptions).toBeUndefined();
+      expect(result.useAwsIamAuth).toBeUndefined();
+    });
+
+    describe('pgOptions SSL handling', () => {
+      it('normalizes enableSsl=Enabled with empty ssl object to ssl=true', () => {
+        const result = parseBeforeSaveConnection({
+          connInfo: {
+            ...serverPortBase(),
+            usePassword: 'Save as plaintext in settings',
+            password: 'p',
+            pgOptions: { enableSsl: 'Enabled', ssl: {} },
+          },
+        });
+        expect(result.pgOptions).toEqual({ ssl: true });
+      });
+
+      it('normalizes enableSsl=Disabled by dropping ssl', () => {
+        const result = parseBeforeSaveConnection({
+          connInfo: {
+            ...serverPortBase(),
+            usePassword: 'Save as plaintext in settings',
+            password: 'p',
+            pgOptions: { enableSsl: 'Disabled', ssl: { rejectUnauthorized: false } },
+          },
+        });
+        expect(result.pgOptions).toBeUndefined(); // no keys left → removed
+      });
+
+      it('keeps a populated ssl object when enableSsl=Enabled', () => {
+        const result = parseBeforeSaveConnection({
+          connInfo: {
+            ...serverPortBase(),
+            usePassword: 'Save as plaintext in settings',
+            password: 'p',
+            pgOptions: { enableSsl: 'Enabled', ssl: { rejectUnauthorized: false } },
+          },
+        });
+        expect(result.pgOptions).toEqual({ ssl: { rejectUnauthorized: false } });
+      });
+    });
+  });
+
+  describe('parseBeforeEditConnection', () => {
+    it('askForPassword=true is exposed as Ask on connect', () => {
+      const result = parseBeforeEditConnection({
+        connInfo: { ...serverPortBase(), askForPassword: true },
+      });
+      expect(result.usePassword).toBe('Ask on connect');
+      expect(result.password).toBeUndefined();
+    });
+
+    it('empty password is exposed as Use empty password', () => {
+      const result = parseBeforeEditConnection({
+        connInfo: { ...serverPortBase(), password: '' },
+      });
+      expect(result.usePassword).toBe('Use empty password');
+      expect(result.askForPassword).toBeUndefined();
+    });
+
+    it('non-empty password is exposed as Save as plaintext in settings', () => {
+      const result = parseBeforeEditConnection({
+        connInfo: { ...serverPortBase(), password: 'secret' },
+      });
+      expect(result.usePassword).toBe('Save as plaintext in settings');
+      expect(result.password).toBe('secret');
+      expect(result.askForPassword).toBeUndefined();
+    });
+
+    it('useAwsIamAuth=true is exposed as IAM database authentication', () => {
+      const result = parseBeforeEditConnection({
+        connInfo: {
+          ...serverPortBase(),
+          useAwsIamAuth: true,
+          awsIamOptions: { region: 'us-east-1' },
+        },
+      });
+      expect(result.usePassword).toBe('IAM database authentication');
+      expect(result.awsIamOptions).toEqual({ region: 'us-east-1' });
+      expect(result.password).toBeUndefined();
+      expect(result.askForPassword).toBeUndefined();
+    });
+
+    it('no auth fields defaults to SQLTools Driver Credentials', () => {
+      const result = parseBeforeEditConnection({
+        connInfo: { ...serverPortBase() },
+      });
+      expect(result.usePassword).toBe('SQLTools Driver Credentials');
+    });
+
+    it('detects Connection String method', () => {
+      const result = parseBeforeEditConnection({
+        connInfo: { connectString: 'postgres://user@host/db' },
+      });
+      expect(result.connectionMethod).toBe('Connection String');
+    });
+
+    it('detects Socket File method', () => {
+      const result = parseBeforeEditConnection({
+        connInfo: { socketPath: '/tmp/.s.PGSQL.5432', database: 'app', username: 'u' },
+      });
+      expect(result.connectionMethod).toBe('Socket File');
+    });
+
+    it('populates enableSsl=Enabled for boolean ssl=true', () => {
+      const result = parseBeforeEditConnection({
+        connInfo: { ...serverPortBase(), pgOptions: { ssl: true } },
+      });
+      expect(result.pgOptions.enableSsl).toBe('Enabled');
+      expect(result.pgOptions.ssl).toEqual({});
+    });
+
+    it('populates enableSsl=Disabled when ssl is absent', () => {
+      const result = parseBeforeEditConnection({
+        connInfo: { ...serverPortBase() },
+      });
+      expect(result.pgOptions.enableSsl).toBe('Disabled');
+    });
+
+    it('round-trips save → edit → save for an IAM connection', () => {
+      const original = {
+        ...serverPortBase(),
+        usePassword: 'IAM database authentication',
+        awsIamOptions: { region: 'us-east-1', profile: 'dev' },
+      };
+
+      const saved = parseBeforeSaveConnection({ connInfo: { ...original } });
+      const editForm = parseBeforeEditConnection({ connInfo: { ...saved } });
+      const resaved = parseBeforeSaveConnection({ connInfo: { ...editForm } });
+
+      expect(resaved).toEqual(saved);
+      expect(resaved.useAwsIamAuth).toBe(true);
+      expect(resaved.awsIamOptions).toEqual({ region: 'us-east-1', profile: 'dev' });
+    });
+
+    it('round-trips save → edit → save for a plaintext password connection', () => {
+      const original = {
+        ...serverPortBase(),
+        usePassword: 'Save as plaintext in settings',
+        password: 'secret',
+      };
+
+      const saved = parseBeforeSaveConnection({ connInfo: { ...original } });
+      const editForm = parseBeforeEditConnection({ connInfo: { ...saved } });
+      const resaved = parseBeforeSaveConnection({ connInfo: { ...editForm } });
+
+      expect(resaved).toEqual(saved);
+      expect(resaved.password).toBe('secret');
+    });
+  });
+});

--- a/packages/driver.pg/src/connection-parser.ts
+++ b/packages/driver.pg/src/connection-parser.ts
@@ -1,0 +1,160 @@
+/**
+ * Pure helpers that transform `connInfo` between the stored settings shape and
+ * the connection-form shape.
+ */
+
+/**
+ * A password mode describes one choice in the "Use password" dropdown.
+ *
+ * - `label`:       user-facing value stored in `connInfo.usePassword` while
+ *                  the user is editing the form.
+ * - `matches`:     case-insensitive substring used to detect the mode on save
+ *                  (kept for backwards-compat with older saved values).
+ * - `owns`:        properties on `connInfo` that this mode manages. On save
+ *                  these are wiped for every *other* mode, so switching modes
+ *                  never leaves stale config behind. On save they are kept
+ *                  for the active mode.
+ * - `onSave`:      optional mutations applied on save (e.g. set a flag).
+ * - `matchesSaved`: predicate used on edit to detect the mode from the stored
+ *                  shape (reverse of `onSave`).
+ */
+interface PasswordMode {
+  readonly label: string;
+  readonly matches: string;
+  readonly owns: ReadonlyArray<string>;
+  readonly onSave?: (connInfo: any) => void;
+  readonly matchesSaved: (connInfo: any) => boolean;
+}
+
+export const PASSWORD_MODES: ReadonlyArray<PasswordMode> = [
+  {
+    label: 'Ask on connect',
+    matches: 'ask',
+    owns: ['askForPassword'],
+    onSave: (c) => { c.askForPassword = true; },
+    matchesSaved: (c) => c.askForPassword === true,
+  },
+  {
+    label: 'Use empty password',
+    matches: 'empty',
+    owns: ['password'],
+    onSave: (c) => { c.password = ''; },
+    matchesSaved: (c) => c.password === '',
+  },
+  {
+    label: 'Save as plaintext in settings',
+    matches: 'save',
+    owns: ['password'],
+    matchesSaved: (c) => typeof c.password === 'string' && c.password.length > 0,
+  },
+  {
+    label: 'IAM database authentication',
+    matches: 'iam',
+    owns: ['useAwsIamAuth', 'awsIamOptions'],
+    onSave: (c) => { c.useAwsIamAuth = true; },
+    matchesSaved: (c) => c.useAwsIamAuth === true,
+  },
+  // "SQLTools Driver Credentials" is the default. It owns nothing so every
+  // other mode's fields get cleaned up when switching to it.
+  {
+    label: 'SQLTools Driver Credentials',
+    matches: 'secure', // kept for backwards-compat with an older internal label
+    owns: [],
+    matchesSaved: () => true, // catch-all fallback
+  },
+];
+
+function findModeFromForm(value: unknown): PasswordMode | undefined {
+  if (typeof value !== 'string') return undefined;
+  const lowered = value.toLowerCase();
+  const match = PASSWORD_MODES.find(m => lowered.includes(m.matches));
+  if (match) return match;
+  // Any non-empty value that didn't match a specific mode falls through to the
+  // default (SQLTools Driver Credentials) so stale fields from other modes get
+  // cleaned up on save.
+  return PASSWORD_MODES[PASSWORD_MODES.length - 1];
+}
+
+function findModeFromSaved(connInfo: any): PasswordMode {
+  // Order matters: specific checks first, catch-all last.
+  return PASSWORD_MODES.find(m => m.matchesSaved(connInfo)) as PasswordMode;
+}
+
+function allOwnedProps(): string[] {
+  const set = new Set<string>();
+  for (const mode of PASSWORD_MODES) {
+    for (const prop of mode.owns) set.add(prop);
+  }
+  return Array.from(set);
+}
+
+export function parseBeforeSaveConnection({ connInfo }: { connInfo: any }): any {
+  const propsToRemove = new Set<string>(['connectionMethod', 'id', 'usePassword']);
+
+  const activeMode = findModeFromForm(connInfo.usePassword);
+  if (activeMode) {
+    activeMode.onSave?.(connInfo);
+    // Remove every owned prop from every *other* mode so stale config is purged.
+    const keep = new Set(activeMode.owns);
+    for (const prop of allOwnedProps()) {
+      if (!keep.has(prop)) propsToRemove.add(prop);
+    }
+  }
+
+  if (connInfo.connectString) {
+    // Connection String mode doesn't use host/port/auth fields.
+    propsToRemove.add('port');
+    for (const prop of allOwnedProps()) propsToRemove.add(prop);
+  }
+
+  for (const prop of propsToRemove) delete connInfo[prop];
+
+  connInfo.pgOptions = connInfo.pgOptions || {};
+  if (connInfo.pgOptions.enableSsl === 'Enabled') {
+    if (typeof connInfo.pgOptions.ssl === 'object' && Object.keys(connInfo.pgOptions.ssl).length === 0) {
+      connInfo.pgOptions.ssl = true;
+    }
+  } else if (connInfo.pgOptions.enableSsl === 'Disabled') {
+    delete connInfo.pgOptions.ssl;
+  }
+  delete connInfo.pgOptions.enableSsl;
+  if (Object.keys(connInfo.pgOptions).length === 0) {
+    delete connInfo.pgOptions;
+  }
+
+  return connInfo;
+}
+
+export function parseBeforeEditConnection({ connInfo }: { connInfo: any }): any {
+  const formData: typeof connInfo = {
+    ...connInfo,
+    connectionMethod: 'Server and Port',
+  };
+  if (connInfo.socketPath) {
+    formData.connectionMethod = 'Socket File';
+  } else if (connInfo.connectString) {
+    formData.connectionMethod = 'Connection String';
+  }
+
+  const savedMode = findModeFromSaved(connInfo);
+  formData.usePassword = savedMode.label;
+
+  // Remove properties owned by *other* modes so the form only shows the
+  // inputs relevant to the active mode.
+  const keep = new Set(savedMode.owns);
+  for (const prop of allOwnedProps()) {
+    if (!keep.has(prop)) delete formData[prop];
+  }
+
+  formData.pgOptions = formData.pgOptions || {};
+  if (formData.pgOptions.ssl) {
+    formData.pgOptions.enableSsl = 'Enabled';
+    if (typeof formData.pgOptions.ssl === 'boolean') {
+      formData.pgOptions.ssl = {};
+    }
+  } else {
+    formData.pgOptions.enableSsl = 'Disabled';
+  }
+
+  return formData;
+}

--- a/packages/driver.pg/src/connection-schema.test.ts
+++ b/packages/driver.pg/src/connection-schema.test.ts
@@ -1,0 +1,178 @@
+import Ajv from 'ajv';
+import * as path from 'path';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const schema = require(path.join(__dirname, '..', 'connection.schema.json'));
+
+describe('pg connection schema', () => {
+  const ajv = new Ajv({ allErrors: true });
+  const validate = ajv.compile(schema);
+
+  const check = (conn: Record<string, unknown>) => {
+    const ok = validate(conn);
+    return { ok, errors: validate.errors };
+  };
+
+  describe('connection method', () => {
+    it('requires connectionMethod', () => {
+      expect(check({}).ok).toBe(false);
+    });
+
+    it('Server and Port requires server, port, database, username', () => {
+      expect(check({
+        connectionMethod: 'Server and Port',
+        server: 'db',
+        port: 5432,
+        database: 'app',
+        username: 'u',
+      }).ok).toBe(true);
+    });
+
+    it('Server and Port rejects missing port', () => {
+      expect(check({
+        connectionMethod: 'Server and Port',
+        server: 'db',
+        database: 'app',
+        username: 'u',
+      }).ok).toBe(false);
+    });
+
+    it('Socket File requires socketPath, database, username', () => {
+      expect(check({
+        connectionMethod: 'Socket File',
+        socketPath: '/tmp/.s.PGSQL.5432',
+        database: 'app',
+        username: 'u',
+      }).ok).toBe(true);
+    });
+
+    it('Socket File rejects missing socketPath', () => {
+      expect(check({
+        connectionMethod: 'Socket File',
+        database: 'app',
+        username: 'u',
+      }).ok).toBe(false);
+    });
+
+    it('Connection String requires connectString', () => {
+      expect(check({
+        connectionMethod: 'Connection String',
+        connectString: 'postgres://u@h/d',
+      }).ok).toBe(true);
+    });
+
+    it('Connection String rejects missing connectString', () => {
+      expect(check({
+        connectionMethod: 'Connection String',
+      }).ok).toBe(false);
+    });
+  });
+
+  describe('usePassword', () => {
+    const baseConn = {
+      connectionMethod: 'Server and Port',
+      server: 'db',
+      port: 5432,
+      database: 'app',
+      username: 'u',
+    };
+
+    it('allows Ask on connect', () => {
+      expect(check({ ...baseConn, usePassword: 'Ask on connect' }).ok).toBe(true);
+    });
+
+    it('allows Use empty password', () => {
+      expect(check({ ...baseConn, usePassword: 'Use empty password' }).ok).toBe(true);
+    });
+
+    it('allows SQLTools Driver Credentials', () => {
+      expect(check({ ...baseConn, usePassword: 'SQLTools Driver Credentials' }).ok).toBe(true);
+    });
+
+    it('Save as plaintext in settings requires password', () => {
+      expect(check({
+        ...baseConn,
+        usePassword: 'Save as plaintext in settings',
+        password: 'secret',
+      }).ok).toBe(true);
+      expect(check({
+        ...baseConn,
+        usePassword: 'Save as plaintext in settings',
+      }).ok).toBe(false);
+    });
+
+    it('rejects unknown usePassword values', () => {
+      expect(check({ ...baseConn, usePassword: 'Wat' }).ok).toBe(false);
+    });
+
+    describe('IAM database authentication', () => {
+      it('accepts a valid IAM connection', () => {
+        expect(check({
+          ...baseConn,
+          usePassword: 'IAM database authentication',
+          awsIamOptions: { region: 'us-east-1' },
+        }).ok).toBe(true);
+      });
+
+      it('accepts a valid IAM connection with profile', () => {
+        expect(check({
+          ...baseConn,
+          usePassword: 'IAM database authentication',
+          awsIamOptions: { region: 'us-east-1', profile: 'dev' },
+        }).ok).toBe(true);
+      });
+
+      it('rejects IAM missing awsIamOptions.region', () => {
+        expect(check({
+          ...baseConn,
+          usePassword: 'IAM database authentication',
+          awsIamOptions: {},
+        }).ok).toBe(false);
+      });
+
+      it('rejects IAM missing awsIamOptions entirely', () => {
+        expect(check({
+          ...baseConn,
+          usePassword: 'IAM database authentication',
+        }).ok).toBe(false);
+      });
+    });
+
+    it('IAM database authentication is in the usePassword enum', () => {
+      expect(schema.definitions.usePassword.enum).toContain('IAM database authentication');
+    });
+  });
+
+  describe('ssh', () => {
+    const baseConn = {
+      connectionMethod: 'Server and Port',
+      server: 'db',
+      port: 5432,
+      database: 'app',
+      username: 'u',
+    };
+
+    it('ssh=Enabled requires sshOptions', () => {
+      expect(check({ ...baseConn, ssh: 'Enabled' }).ok).toBe(false);
+    });
+
+    it('ssh=Enabled with sshOptions host+username is valid', () => {
+      expect(check({
+        ...baseConn,
+        ssh: 'Enabled',
+        sshOptions: { host: 'bastion.example.com', username: 'ec2-user' },
+      }).ok).toBe(true);
+    });
+
+    it('ssh=Enabled with sshOptions missing host is rejected', () => {
+      expect(check({
+        ...baseConn,
+        ssh: 'Enabled',
+        sshOptions: { username: 'ec2-user' },
+      }).ok).toBe(false);
+    });
+
+    it('ssh=Disabled is valid', () => {
+      expect(check({ ...baseConn, ssh: 'Disabled' }).ok).toBe(true);
+    });
+  });
+});

--- a/packages/driver.pg/src/extension.ts
+++ b/packages/driver.pg/src/extension.ts
@@ -1,6 +1,7 @@
 import { IExtension, IExtensionPlugin, IDriverExtensionApi } from '@sqltools/types';
 import { ExtensionContext, extensions, authentication } from 'vscode';
 import { DRIVER_ALIASES } from './constants';
+import { parseBeforeSaveConnection, parseBeforeEditConnection } from './connection-parser';
 const { publisher, name } = require('../package.json');
 const driverName = 'PostgreSQL/Cockroach';
 const AUTHENTICATION_PROVIDER = 'sqltools-driver-credentials';
@@ -48,82 +49,14 @@ export async function activate(extContext: ExtensionContext): Promise<IDriverExt
   api.registerPlugin(plugin);
   return {
     driverName,
-    parseBeforeSaveConnection: ({ connInfo }) => {
-      const propsToRemove = ['connectionMethod', 'id', 'usePassword'];
-      if (connInfo.usePassword) {
-        if (connInfo.usePassword.toString().toLowerCase().includes('ask')) {
-          connInfo.askForPassword = true;
-          propsToRemove.push('password');
-        } else if (connInfo.usePassword.toString().toLowerCase().includes('empty')) {
-          connInfo.password = '';
-          propsToRemove.push('askForPassword');
-        } else if (connInfo.usePassword.toString().toLowerCase().includes('save')) {
-          propsToRemove.push('askForPassword');
-        } else if (connInfo.usePassword.toString().toLowerCase().includes('secure')) {
-          propsToRemove.push('password');
-          propsToRemove.push('askForPassword');
-        }
-      }
-      if (connInfo.connectString) {
-        propsToRemove.push('port');
-        propsToRemove.push('askForPassword');
-      }
-      propsToRemove.forEach(p => delete connInfo[p]);
-
-      connInfo.pgOptions = connInfo.pgOptions || {};
-      if (connInfo.pgOptions.enableSsl === 'Enabled') {
-        if (typeof connInfo.pgOptions.ssl === 'object' && Object.keys(connInfo.pgOptions.ssl).length === 0) {
-          connInfo.pgOptions.ssl = true;
-        }
-      } else if (connInfo.pgOptions.enableSsl === 'Disabled') {
-        delete connInfo.pgOptions.ssl
-      }
-      delete connInfo.pgOptions.enableSsl;
-      if (Object.keys(connInfo.pgOptions).length === 0) {
-        delete connInfo.pgOptions;
-      }
-
-      return connInfo;
-    },
-    parseBeforeEditConnection: ({ connInfo }) => {
-      const formData: typeof connInfo = {
-        ...connInfo,
-        connectionMethod: 'Server and Port',
-      };
-      if (connInfo.socketPath) {
-        formData.connectionMethod = 'Socket File';
-      } else if (connInfo.connectString) {
-        formData.connectionMethod = 'Connection String';
-      }
-
-      if (connInfo.askForPassword) {
-        formData.usePassword = 'Ask on connect';
-        delete formData.password;
-      } else if (typeof connInfo.password === 'string') {
-        delete formData.askForPassword;
-        formData.usePassword = connInfo.password ? 'Save as plaintext in settings' : 'Use empty password';
-      } else {
-        formData.usePassword = 'SQLTools Driver Credentials';
-      }
-
-      formData.pgOptions = formData.pgOptions || {};
-      if (formData.pgOptions.ssl) {
-        formData.pgOptions.enableSsl = 'Enabled';
-        if (typeof formData.pgOptions.ssl === 'boolean') {
-          formData.pgOptions.ssl = {};
-        }
-      } else {
-        formData.pgOptions.enableSsl = 'Disabled';
-      }
-
-      return formData;
-    },
+    parseBeforeSaveConnection,
+    parseBeforeEditConnection,
     resolveConnection: async ({ connInfo }) => {
       /**
        * This hook is called after a connection definition has been fetched
        * from settings and is about to be used to connect.
        */
-      if (connInfo.password === undefined && !connInfo.askForPassword && !connInfo.connectString) {
+      if (connInfo.password === undefined && !connInfo.askForPassword && !connInfo.connectString && !connInfo.useAwsIamAuth) {
         const scopes = [connInfo.name, (connInfo.username || "")];
         let session = await authentication.getSession(
           AUTHENTICATION_PROVIDER,

--- a/packages/driver.pg/src/ls/aws-iam.test.ts
+++ b/packages/driver.pg/src/ls/aws-iam.test.ts
@@ -1,0 +1,33 @@
+import { validateIamAuthOptions } from './aws-iam';
+
+describe('pg aws-iam validateIamAuthOptions', () => {
+  const pool = { ssl: true, hostname: 'h', port: 5432, username: 'u' };
+
+  it('passes for a fully-formed config', () => {
+    expect(() => validateIamAuthOptions({ region: 'us-east-1' }, pool)).not.toThrow();
+  });
+
+  it('rejects when region is missing', () => {
+    expect(() => validateIamAuthOptions({}, pool)).toThrow(/requires a region/);
+  });
+
+  it('rejects when SSL is disabled', () => {
+    expect(() => validateIamAuthOptions({ region: 'us-east-1' }, { ...pool, ssl: false }))
+      .toThrow(/requires SSL. Enable SSL in the pgOptions/);
+  });
+
+  it('rejects when hostname is missing', () => {
+    expect(() => validateIamAuthOptions({ region: 'us-east-1' }, { ...pool, hostname: undefined }))
+      .toThrow(/host, port and username/);
+  });
+
+  it('rejects when port is missing', () => {
+    expect(() => validateIamAuthOptions({ region: 'us-east-1' }, { ...pool, port: undefined }))
+      .toThrow(/host, port and username/);
+  });
+
+  it('rejects when username is missing', () => {
+    expect(() => validateIamAuthOptions({ region: 'us-east-1' }, { ...pool, username: undefined }))
+      .toThrow(/host, port and username/);
+  });
+});

--- a/packages/driver.pg/src/ls/aws-iam.ts
+++ b/packages/driver.pg/src/ls/aws-iam.ts
@@ -1,0 +1,56 @@
+/**
+ * Signs short-lived IAM database authentication tokens for Amazon RDS / Aurora.
+ *
+ * The AWS SDK is imported dynamically so the cost is only paid by users who
+ * actually turn on IAM auth.
+ */
+
+export interface AwsIamAuthOptions {
+  region?: string;
+  profile?: string;
+}
+
+export interface SignAwsIamTokenParams {
+  hostname: string;
+  port: number;
+  username: string;
+  region: string;
+  profile?: string;
+}
+
+export async function signAwsIamToken(params: SignAwsIamTokenParams): Promise<string> {
+  const { Signer } = await import('@aws-sdk/rds-signer');
+
+  let credentials: any;
+  if (params.profile) {
+    const { fromIni } = await import('@aws-sdk/credential-providers');
+    credentials = fromIni({ profile: params.profile });
+  }
+
+  const signer = new Signer({
+    region: params.region,
+    hostname: params.hostname,
+    port: params.port,
+    username: params.username,
+    ...(credentials ? { credentials } : {}),
+  });
+
+  return signer.getAuthToken();
+}
+
+export function validateIamAuthOptions(
+  options: AwsIamAuthOptions,
+  poolHas: { ssl: boolean; hostname?: string; port?: number; username?: string }
+): void {
+  if (!options.region) {
+    throw new Error('IAM database authentication requires a region in awsIamOptions.');
+  }
+  if (!poolHas.ssl) {
+    throw new Error(
+      'IAM database authentication requires SSL. Enable SSL in the pgOptions and supply the Amazon RDS CA bundle.'
+    );
+  }
+  if (!poolHas.hostname || !poolHas.port || !poolHas.username) {
+    throw new Error('IAM database authentication requires host, port and username to be set.');
+  }
+}

--- a/packages/driver.pg/src/ls/driver.iam.test.ts
+++ b/packages/driver.pg/src/ls/driver.iam.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Integration-style tests for the IAM auth code path in the pg driver's open().
+ * We mock the `pg` library and the local `./aws-iam` helper so the test
+ * exercises the driver logic without opening a real connection or shipping
+ * a real token.
+ */
+
+const poolConstructorCalls: Array<Record<string, unknown>> = [];
+const poolConnectMock = jest.fn();
+jest.mock('pg', () => {
+  class FakePool {
+    public readonly config: Record<string, unknown>;
+    constructor(config: Record<string, unknown>) {
+      this.config = config;
+      poolConstructorCalls.push(config);
+    }
+    public connect = poolConnectMock;
+    public end = jest.fn();
+  }
+  return {
+    Pool: FakePool,
+    types: {
+      setTypeParser: jest.fn(),
+      builtins: { TIMESTAMP: 1114, TIMESTAMPTZ: 1184, DATE: 1082 },
+    },
+    Client: class {},
+  };
+});
+
+const signAwsIamTokenMock = jest.fn();
+const validateIamAuthOptionsMock = jest.fn();
+jest.mock('./aws-iam', () => ({
+  signAwsIamToken: signAwsIamTokenMock,
+  validateIamAuthOptions: validateIamAuthOptionsMock,
+}));
+
+import PostgreSQL from './driver';
+
+function makeDriver(credentials: Record<string, unknown>): PostgreSQL {
+  const getWorkspaceFolders = jest.fn().mockResolvedValue([]);
+  return new (PostgreSQL as any)(credentials, getWorkspaceFolders);
+}
+
+describe('pg driver IAM auth', () => {
+  beforeEach(() => {
+    poolConstructorCalls.length = 0;
+    poolConnectMock.mockReset();
+    signAwsIamTokenMock.mockReset();
+    validateIamAuthOptionsMock.mockReset();
+    poolConnectMock.mockResolvedValue({
+      on: jest.fn(),
+      query: jest.fn(),
+      release: jest.fn(),
+    });
+  });
+
+  it('installs an async password callback that delegates to signAwsIamToken', async () => {
+    signAwsIamTokenMock.mockResolvedValue('fresh-token');
+
+    const driver = makeDriver({
+      driver: 'PostgreSQL',
+      server: 'db.example.com',
+      port: 5432,
+      database: 'app',
+      username: 'dbuser',
+      useAwsIamAuth: true,
+      awsIamOptions: { region: 'us-east-1', profile: 'dev' },
+      pgOptions: { ssl: { rejectUnauthorized: false } },
+    });
+
+    await driver.open();
+
+    expect(validateIamAuthOptionsMock).toHaveBeenCalledTimes(1);
+    expect(validateIamAuthOptionsMock).toHaveBeenCalledWith(
+      { region: 'us-east-1', profile: 'dev' },
+      { ssl: true, hostname: 'db.example.com', port: 5432, username: 'dbuser' },
+    );
+
+    expect(poolConstructorCalls).toHaveLength(1);
+    const config = poolConstructorCalls[0];
+    expect(typeof config.password).toBe('function');
+
+    const token = await (config.password as () => Promise<string>)();
+    expect(token).toBe('fresh-token');
+    expect(signAwsIamTokenMock).toHaveBeenCalledWith({
+      hostname: 'db.example.com',
+      port: 5432,
+      username: 'dbuser',
+      region: 'us-east-1',
+      profile: 'dev',
+    });
+  });
+
+  it('propagates validation errors from validateIamAuthOptions', async () => {
+    validateIamAuthOptionsMock.mockImplementationOnce(() => {
+      throw new Error('IAM database authentication requires a region in awsIamOptions.');
+    });
+
+    const driver = makeDriver({
+      driver: 'PostgreSQL',
+      server: 'db.example.com',
+      port: 5432,
+      database: 'app',
+      username: 'dbuser',
+      useAwsIamAuth: true,
+      awsIamOptions: {},
+      pgOptions: { ssl: true },
+    });
+
+    await expect(driver.open()).rejects.toThrow(/requires a region/);
+    expect(poolConstructorCalls).toHaveLength(0);
+    expect(signAwsIamTokenMock).not.toHaveBeenCalled();
+  });
+
+  it('does not install the IAM callback when useAwsIamAuth is false', async () => {
+    const driver = makeDriver({
+      driver: 'PostgreSQL',
+      server: 'db.example.com',
+      port: 5432,
+      database: 'app',
+      username: 'dbuser',
+      password: 'plain-password',
+      pgOptions: { ssl: true },
+    });
+
+    await driver.open();
+
+    expect(poolConstructorCalls).toHaveLength(1);
+    expect(poolConstructorCalls[0].password).toBe('plain-password');
+    expect(validateIamAuthOptionsMock).not.toHaveBeenCalled();
+    expect(signAwsIamTokenMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/driver.pg/src/ls/driver.ts
+++ b/packages/driver.pg/src/ls/driver.ts
@@ -6,6 +6,7 @@ import fs from 'fs';
 import zipObject from 'lodash/zipObject';
 import { parse as queryParse } from '@sqltools/util/query';
 import generateId from '@sqltools/util/internal-id';
+import { signAwsIamToken, validateIamAuthOptions } from './aws-iam';
 
 const rawValue = (v: string) => v;
 
@@ -82,6 +83,28 @@ export default class PostgreSQL extends AbstractDriver<Pool, PoolConfig> impleme
         } else {
           poolConfig.ssl =  ssl || false;
         }
+      }
+
+      if (this.credentials.useAwsIamAuth && !this.credentials.connectString) {
+        const awsIamOptions = this.credentials.awsIamOptions || {};
+        validateIamAuthOptions(awsIamOptions, {
+          ssl: !!poolConfig.ssl,
+          hostname: poolConfig.host,
+          port: poolConfig.port,
+          username: poolConfig.user,
+        });
+        const hostname = poolConfig.host;
+        const port = poolConfig.port;
+        const username = poolConfig.user;
+        // Use pg's async password callback so every new pool connection gets
+        // a freshly-signed token (IAM auth tokens expire after 15 minutes).
+        (poolConfig as any).password = () => signAwsIamToken({
+          hostname,
+          port,
+          username,
+          region: awsIamOptions.region,
+          profile: awsIamOptions.profile,
+        });
       }
 
       const pool = new Pool(poolConfig);

--- a/packages/driver.pg/ui.schema.json
+++ b/packages/driver.pg/ui.schema.json
@@ -9,6 +9,7 @@
     "username",
     "usePassword",
     "password",
+    "awsIamOptions",
     "pgOptions",
     "ssh",
     "sshOptions"
@@ -16,6 +17,14 @@
   "password": { "ui:widget": "password" },
   "askForPassword": { "ui:widget": "hidden" },
   "socketPath": { "ui:widget": "file" },
+  "awsIamOptions": {
+    "region": {
+      "ui:help": "AWS region of the Amazon RDS / Aurora instance (e.g. us-east-1, eu-west-1)."
+    },
+    "profile": {
+      "ui:help": "Named profile from your AWS shared config. Leave empty to use the default credential provider chain (env vars, default profile, IMDS, SSO, etc.)."
+    }
+  },
   "pgOptions": {
     "ui:order": ["enableSsl", "ssl", "*"],
     "statement_timeout": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,507 @@
 # yarn lockfile v1
 
 
+"@aws-crypto/sha256-browser@5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz#153895ef1dba6f9fce38af550e0ef58988eb649e"
+  integrity sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==
+  dependencies:
+    "@aws-crypto/sha256-js" "^5.2.0"
+    "@aws-crypto/supports-web-crypto" "^5.2.0"
+    "@aws-crypto/util" "^5.2.0"
+    "@aws-sdk/types" "^3.222.0"
+    "@aws-sdk/util-locate-window" "^3.0.0"
+    "@smithy/util-utf8" "^2.0.0"
+    tslib "^2.6.2"
+
+"@aws-crypto/sha256-js@5.2.0", "@aws-crypto/sha256-js@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz#c4fdb773fdbed9a664fc1a95724e206cf3860042"
+  integrity sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==
+  dependencies:
+    "@aws-crypto/util" "^5.2.0"
+    "@aws-sdk/types" "^3.222.0"
+    tslib "^2.6.2"
+
+"@aws-crypto/supports-web-crypto@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz#a1e399af29269be08e695109aa15da0a07b5b5fb"
+  integrity sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==
+  dependencies:
+    tslib "^2.6.2"
+
+"@aws-crypto/util@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/util/-/util-5.2.0.tgz#71284c9cffe7927ddadac793c14f14886d3876da"
+  integrity sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==
+  dependencies:
+    "@aws-sdk/types" "^3.222.0"
+    "@smithy/util-utf8" "^2.0.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/client-cognito-identity@3.1041.0":
+  version "3.1041.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.1041.0.tgz#43d74d2ae0a99b2bdd238169caf942cc5dc753a6"
+  integrity sha512-h8DxvCsv95RSHTZPyEwGCqOyiQYVWQ4tFe5im4d0qFvFc9xRmseTu3ZsQ9nd+uOzU9rkCoDHClyqUxXU7nm90Q==
+  dependencies:
+    "@aws-crypto/sha256-browser" "5.2.0"
+    "@aws-crypto/sha256-js" "5.2.0"
+    "@aws-sdk/core" "^3.974.8"
+    "@aws-sdk/credential-provider-node" "^3.972.39"
+    "@aws-sdk/middleware-host-header" "^3.972.10"
+    "@aws-sdk/middleware-logger" "^3.972.10"
+    "@aws-sdk/middleware-recursion-detection" "^3.972.11"
+    "@aws-sdk/middleware-user-agent" "^3.972.38"
+    "@aws-sdk/region-config-resolver" "^3.972.13"
+    "@aws-sdk/types" "^3.973.8"
+    "@aws-sdk/util-endpoints" "^3.996.8"
+    "@aws-sdk/util-user-agent-browser" "^3.972.10"
+    "@aws-sdk/util-user-agent-node" "^3.973.24"
+    "@smithy/config-resolver" "^4.4.17"
+    "@smithy/core" "^3.23.17"
+    "@smithy/fetch-http-handler" "^5.3.17"
+    "@smithy/hash-node" "^4.2.14"
+    "@smithy/invalid-dependency" "^4.2.14"
+    "@smithy/middleware-content-length" "^4.2.14"
+    "@smithy/middleware-endpoint" "^4.4.32"
+    "@smithy/middleware-retry" "^4.5.7"
+    "@smithy/middleware-serde" "^4.2.20"
+    "@smithy/middleware-stack" "^4.2.14"
+    "@smithy/node-config-provider" "^4.3.14"
+    "@smithy/node-http-handler" "^4.6.1"
+    "@smithy/protocol-http" "^5.3.14"
+    "@smithy/smithy-client" "^4.12.13"
+    "@smithy/types" "^4.14.1"
+    "@smithy/url-parser" "^4.2.14"
+    "@smithy/util-base64" "^4.3.2"
+    "@smithy/util-body-length-browser" "^4.2.2"
+    "@smithy/util-body-length-node" "^4.2.3"
+    "@smithy/util-defaults-mode-browser" "^4.3.49"
+    "@smithy/util-defaults-mode-node" "^4.2.54"
+    "@smithy/util-endpoints" "^3.4.2"
+    "@smithy/util-middleware" "^4.2.14"
+    "@smithy/util-retry" "^4.3.6"
+    "@smithy/util-utf8" "^4.2.2"
+    tslib "^2.6.2"
+
+"@aws-sdk/core@^3.974.8":
+  version "3.974.8"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/core/-/core-3.974.8.tgz#cdd51195a31322f1e429e66919eb18da8944c081"
+  integrity sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==
+  dependencies:
+    "@aws-sdk/types" "^3.973.8"
+    "@aws-sdk/xml-builder" "^3.972.22"
+    "@smithy/core" "^3.23.17"
+    "@smithy/node-config-provider" "^4.3.14"
+    "@smithy/property-provider" "^4.2.14"
+    "@smithy/protocol-http" "^5.3.14"
+    "@smithy/signature-v4" "^5.3.14"
+    "@smithy/smithy-client" "^4.12.13"
+    "@smithy/types" "^4.14.1"
+    "@smithy/util-base64" "^4.3.2"
+    "@smithy/util-middleware" "^4.2.14"
+    "@smithy/util-retry" "^4.3.6"
+    "@smithy/util-utf8" "^4.2.2"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-cognito-identity@^3.972.31":
+  version "3.972.31"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.972.31.tgz#a00772e4f1416c793110831e78d27d69eb34d0c8"
+  integrity sha512-W5JtzDp3ejzhOOknXlnt+vJsNN2GZdAcBK+hR7HQ1DCacXqS0UpmnIyihIU7CK0IB+XYWeBaN3bBv4pXavp7Vg==
+  dependencies:
+    "@aws-sdk/nested-clients" "^3.997.6"
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/property-provider" "^4.2.14"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-env@^3.972.34":
+  version "3.972.34"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.34.tgz#9d420adf02e7604094a641ae613a353aa86e1b83"
+  integrity sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ==
+  dependencies:
+    "@aws-sdk/core" "^3.974.8"
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/property-provider" "^4.2.14"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-http@^3.972.36":
+  version "3.972.36"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.36.tgz#842268559da2ffc5855cde1e90e7302d53639c08"
+  integrity sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg==
+  dependencies:
+    "@aws-sdk/core" "^3.974.8"
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/fetch-http-handler" "^5.3.17"
+    "@smithy/node-http-handler" "^4.6.1"
+    "@smithy/property-provider" "^4.2.14"
+    "@smithy/protocol-http" "^5.3.14"
+    "@smithy/smithy-client" "^4.12.13"
+    "@smithy/types" "^4.14.1"
+    "@smithy/util-stream" "^4.5.25"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-ini@^3.972.38":
+  version "3.972.38"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.38.tgz#e20955fdfe4a88149b20dc7e25a517542e1dfd9f"
+  integrity sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ==
+  dependencies:
+    "@aws-sdk/core" "^3.974.8"
+    "@aws-sdk/credential-provider-env" "^3.972.34"
+    "@aws-sdk/credential-provider-http" "^3.972.36"
+    "@aws-sdk/credential-provider-login" "^3.972.38"
+    "@aws-sdk/credential-provider-process" "^3.972.34"
+    "@aws-sdk/credential-provider-sso" "^3.972.38"
+    "@aws-sdk/credential-provider-web-identity" "^3.972.38"
+    "@aws-sdk/nested-clients" "^3.997.6"
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/credential-provider-imds" "^4.2.14"
+    "@smithy/property-provider" "^4.2.14"
+    "@smithy/shared-ini-file-loader" "^4.4.9"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-login@^3.972.38":
+  version "3.972.38"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.38.tgz#278437712c02a3ad1785f70c93b4f591cb3f6491"
+  integrity sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww==
+  dependencies:
+    "@aws-sdk/core" "^3.974.8"
+    "@aws-sdk/nested-clients" "^3.997.6"
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/property-provider" "^4.2.14"
+    "@smithy/protocol-http" "^5.3.14"
+    "@smithy/shared-ini-file-loader" "^4.4.9"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-node@^3.972.39":
+  version "3.972.39"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.39.tgz#71f87848b7615dda4f31a57b113be9666e4bbd1a"
+  integrity sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg==
+  dependencies:
+    "@aws-sdk/credential-provider-env" "^3.972.34"
+    "@aws-sdk/credential-provider-http" "^3.972.36"
+    "@aws-sdk/credential-provider-ini" "^3.972.38"
+    "@aws-sdk/credential-provider-process" "^3.972.34"
+    "@aws-sdk/credential-provider-sso" "^3.972.38"
+    "@aws-sdk/credential-provider-web-identity" "^3.972.38"
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/credential-provider-imds" "^4.2.14"
+    "@smithy/property-provider" "^4.2.14"
+    "@smithy/shared-ini-file-loader" "^4.4.9"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-process@^3.972.34":
+  version "3.972.34"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.34.tgz#c964275be1a528ac73ade6d98c309fb6b7cdfb68"
+  integrity sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q==
+  dependencies:
+    "@aws-sdk/core" "^3.974.8"
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/property-provider" "^4.2.14"
+    "@smithy/shared-ini-file-loader" "^4.4.9"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-sso@^3.972.38":
+  version "3.972.38"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.38.tgz#ec754bfecb2426a3307e19ef7e6c6b6438a327c6"
+  integrity sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA==
+  dependencies:
+    "@aws-sdk/core" "^3.974.8"
+    "@aws-sdk/nested-clients" "^3.997.6"
+    "@aws-sdk/token-providers" "3.1041.0"
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/property-provider" "^4.2.14"
+    "@smithy/shared-ini-file-loader" "^4.4.9"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-web-identity@^3.972.38":
+  version "3.972.38"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.38.tgz#149951ef6e12db5292118e8ed5d95133c24ad719"
+  integrity sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==
+  dependencies:
+    "@aws-sdk/core" "^3.974.8"
+    "@aws-sdk/nested-clients" "^3.997.6"
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/property-provider" "^4.2.14"
+    "@smithy/shared-ini-file-loader" "^4.4.9"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-providers@3.1041.0", "@aws-sdk/credential-providers@^3.540.0":
+  version "3.1041.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-providers/-/credential-providers-3.1041.0.tgz#0aacac812a1a00b80e866d51dcc86234a707b62e"
+  integrity sha512-Ps7dcWV1JbXKoFy8QpWhTpWkX0x2tiZFmDdgojK98/rqyybPdwEtGB8xY/N2uJjE0MZkrV9X7T3Xrnk/rGFoNw==
+  dependencies:
+    "@aws-sdk/client-cognito-identity" "3.1041.0"
+    "@aws-sdk/core" "^3.974.8"
+    "@aws-sdk/credential-provider-cognito-identity" "^3.972.31"
+    "@aws-sdk/credential-provider-env" "^3.972.34"
+    "@aws-sdk/credential-provider-http" "^3.972.36"
+    "@aws-sdk/credential-provider-ini" "^3.972.38"
+    "@aws-sdk/credential-provider-login" "^3.972.38"
+    "@aws-sdk/credential-provider-node" "^3.972.39"
+    "@aws-sdk/credential-provider-process" "^3.972.34"
+    "@aws-sdk/credential-provider-sso" "^3.972.38"
+    "@aws-sdk/credential-provider-web-identity" "^3.972.38"
+    "@aws-sdk/nested-clients" "^3.997.6"
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/config-resolver" "^4.4.17"
+    "@smithy/core" "^3.23.17"
+    "@smithy/credential-provider-imds" "^4.2.14"
+    "@smithy/node-config-provider" "^4.3.14"
+    "@smithy/property-provider" "^4.2.14"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-host-header@^3.972.10":
+  version "3.972.10"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz#e63b91959ce46948d789582351b2a44c4876e924"
+  integrity sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==
+  dependencies:
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/protocol-http" "^5.3.14"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-logger@^3.972.10":
+  version "3.972.10"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz#d92b3374dcaddd523930bdff441207946343c270"
+  integrity sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==
+  dependencies:
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-recursion-detection@^3.972.11":
+  version "3.972.11"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz#5659982a34fa58c69cbd358c2987c32aefd2bd91"
+  integrity sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==
+  dependencies:
+    "@aws-sdk/types" "^3.973.8"
+    "@aws/lambda-invoke-store" "^0.2.2"
+    "@smithy/protocol-http" "^5.3.14"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-sdk-s3@^3.972.37":
+  version "3.972.37"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.37.tgz#82ef4953cddd3373d2942d07a5d2baf443bbf3ea"
+  integrity sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA==
+  dependencies:
+    "@aws-sdk/core" "^3.974.8"
+    "@aws-sdk/types" "^3.973.8"
+    "@aws-sdk/util-arn-parser" "^3.972.3"
+    "@smithy/core" "^3.23.17"
+    "@smithy/node-config-provider" "^4.3.14"
+    "@smithy/protocol-http" "^5.3.14"
+    "@smithy/signature-v4" "^5.3.14"
+    "@smithy/smithy-client" "^4.12.13"
+    "@smithy/types" "^4.14.1"
+    "@smithy/util-config-provider" "^4.2.2"
+    "@smithy/util-middleware" "^4.2.14"
+    "@smithy/util-stream" "^4.5.25"
+    "@smithy/util-utf8" "^4.2.2"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-user-agent@^3.972.38":
+  version "3.972.38"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.38.tgz#626d9a2499f5a6398a4db917abeeaac14b54c6cb"
+  integrity sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A==
+  dependencies:
+    "@aws-sdk/core" "^3.974.8"
+    "@aws-sdk/types" "^3.973.8"
+    "@aws-sdk/util-endpoints" "^3.996.8"
+    "@smithy/core" "^3.23.17"
+    "@smithy/protocol-http" "^5.3.14"
+    "@smithy/types" "^4.14.1"
+    "@smithy/util-retry" "^4.3.6"
+    tslib "^2.6.2"
+
+"@aws-sdk/nested-clients@^3.997.6":
+  version "3.997.6"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/nested-clients/-/nested-clients-3.997.6.tgz#17433cfac2160ec620a14cbff9d2b33675712cae"
+  integrity sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w==
+  dependencies:
+    "@aws-crypto/sha256-browser" "5.2.0"
+    "@aws-crypto/sha256-js" "5.2.0"
+    "@aws-sdk/core" "^3.974.8"
+    "@aws-sdk/middleware-host-header" "^3.972.10"
+    "@aws-sdk/middleware-logger" "^3.972.10"
+    "@aws-sdk/middleware-recursion-detection" "^3.972.11"
+    "@aws-sdk/middleware-user-agent" "^3.972.38"
+    "@aws-sdk/region-config-resolver" "^3.972.13"
+    "@aws-sdk/signature-v4-multi-region" "^3.996.25"
+    "@aws-sdk/types" "^3.973.8"
+    "@aws-sdk/util-endpoints" "^3.996.8"
+    "@aws-sdk/util-user-agent-browser" "^3.972.10"
+    "@aws-sdk/util-user-agent-node" "^3.973.24"
+    "@smithy/config-resolver" "^4.4.17"
+    "@smithy/core" "^3.23.17"
+    "@smithy/fetch-http-handler" "^5.3.17"
+    "@smithy/hash-node" "^4.2.14"
+    "@smithy/invalid-dependency" "^4.2.14"
+    "@smithy/middleware-content-length" "^4.2.14"
+    "@smithy/middleware-endpoint" "^4.4.32"
+    "@smithy/middleware-retry" "^4.5.7"
+    "@smithy/middleware-serde" "^4.2.20"
+    "@smithy/middleware-stack" "^4.2.14"
+    "@smithy/node-config-provider" "^4.3.14"
+    "@smithy/node-http-handler" "^4.6.1"
+    "@smithy/protocol-http" "^5.3.14"
+    "@smithy/smithy-client" "^4.12.13"
+    "@smithy/types" "^4.14.1"
+    "@smithy/url-parser" "^4.2.14"
+    "@smithy/util-base64" "^4.3.2"
+    "@smithy/util-body-length-browser" "^4.2.2"
+    "@smithy/util-body-length-node" "^4.2.3"
+    "@smithy/util-defaults-mode-browser" "^4.3.49"
+    "@smithy/util-defaults-mode-node" "^4.2.54"
+    "@smithy/util-endpoints" "^3.4.2"
+    "@smithy/util-middleware" "^4.2.14"
+    "@smithy/util-retry" "^4.3.6"
+    "@smithy/util-utf8" "^4.2.2"
+    tslib "^2.6.2"
+
+"@aws-sdk/rds-signer@^3.540.0":
+  version "3.1041.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/rds-signer/-/rds-signer-3.1041.0.tgz#1dc89f235f246713b5954b3096aac55e70e62563"
+  integrity sha512-u2NT7lDgY1gjJLcInlnMmNOmXyjwc4G/NHycwLdw4vra/BN2ItQY9QJYenwim/B4rQ9U7dH47MHY1d5RJKuHUQ==
+  dependencies:
+    "@aws-crypto/sha256-browser" "5.2.0"
+    "@aws-crypto/sha256-js" "5.2.0"
+    "@aws-sdk/credential-providers" "3.1041.0"
+    "@aws-sdk/util-format-url" "^3.972.10"
+    "@smithy/config-resolver" "^4.4.17"
+    "@smithy/hash-node" "^4.2.14"
+    "@smithy/invalid-dependency" "^4.2.14"
+    "@smithy/node-config-provider" "^4.3.14"
+    "@smithy/protocol-http" "^5.3.14"
+    "@smithy/signature-v4" "^5.3.14"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/region-config-resolver@^3.972.13":
+  version "3.972.13"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz#bd32748c2d41b62be838fec76c4b87d4370939c6"
+  integrity sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==
+  dependencies:
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/config-resolver" "^4.4.17"
+    "@smithy/node-config-provider" "^4.3.14"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/signature-v4-multi-region@^3.996.25":
+  version "3.996.25"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.25.tgz#b50651b7e4f9c82482416caa9953ad17645d4a2d"
+  integrity sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==
+  dependencies:
+    "@aws-sdk/middleware-sdk-s3" "^3.972.37"
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/protocol-http" "^5.3.14"
+    "@smithy/signature-v4" "^5.3.14"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/token-providers@3.1041.0":
+  version "3.1041.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/token-providers/-/token-providers-3.1041.0.tgz#f3f068010780fc85fc4a7faa6a080cfb8afd73a4"
+  integrity sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==
+  dependencies:
+    "@aws-sdk/core" "^3.974.8"
+    "@aws-sdk/nested-clients" "^3.997.6"
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/property-provider" "^4.2.14"
+    "@smithy/shared-ini-file-loader" "^4.4.9"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/types@^3.222.0", "@aws-sdk/types@^3.973.8":
+  version "3.973.8"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.973.8.tgz#7352cb74a5f8bae1218eee63e714cf94302911c5"
+  integrity sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==
+  dependencies:
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/util-arn-parser@^3.972.3":
+  version "3.972.3"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz#ed989862bbb172ce16d9e1cd5790e5fe367219c2"
+  integrity sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==
+  dependencies:
+    tslib "^2.6.2"
+
+"@aws-sdk/util-endpoints@^3.996.8":
+  version "3.996.8"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz#ad5c4f09b93482c0861d49d8a025edc2b0d2f5ec"
+  integrity sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==
+  dependencies:
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/types" "^4.14.1"
+    "@smithy/url-parser" "^4.2.14"
+    "@smithy/util-endpoints" "^3.4.2"
+    tslib "^2.6.2"
+
+"@aws-sdk/util-format-url@^3.972.10":
+  version "3.972.10"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-format-url/-/util-format-url-3.972.10.tgz#63184b56627b50842cf37cc0e63251944fc234ed"
+  integrity sha512-DEKiHNJVtNxdyTeQspzY+15Po/kHm6sF0Cs4HV9Q2+lplB63+DrvdeiSoOSdWEWAoO2RcY1veoXVDz2tWxWCgQ==
+  dependencies:
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/querystring-builder" "^4.2.14"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/util-locate-window@^3.0.0":
+  version "3.965.5"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz#e30e6ff2aff6436209ed42c765dec2d2a48df7c0"
+  integrity sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==
+  dependencies:
+    tslib "^2.6.2"
+
+"@aws-sdk/util-user-agent-browser@^3.972.10":
+  version "3.972.10"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz#e29be10389db9db12b2d8246ad247a89038f4c60"
+  integrity sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==
+  dependencies:
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/types" "^4.14.1"
+    bowser "^2.11.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/util-user-agent-node@^3.973.24":
+  version "3.973.24"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.24.tgz#cf44a63b92adfecaeb8cb9f948b390456310566a"
+  integrity sha512-ZWwlkjcIp7cEL8ZfTpTAPNkwx25p7xol0xlKoWVVf22+nsjwmLcHYtTPjIV1cSpmB/b6DaK4cb1fSkvCXHgRdw==
+  dependencies:
+    "@aws-sdk/middleware-user-agent" "^3.972.38"
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/node-config-provider" "^4.3.14"
+    "@smithy/types" "^4.14.1"
+    "@smithy/util-config-provider" "^4.2.2"
+    tslib "^2.6.2"
+
+"@aws-sdk/xml-builder@^3.972.22":
+  version "3.972.22"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/xml-builder/-/xml-builder-3.972.22.tgz#1e44ca9fd9c3fdc3d9af9540ced024f34cfc60b2"
+  integrity sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==
+  dependencies:
+    "@nodable/entities" "2.1.0"
+    "@smithy/types" "^4.14.1"
+    fast-xml-parser "5.7.2"
+    tslib "^2.6.2"
+
+"@aws/lambda-invoke-store@^0.2.2":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz#802f6a50f6b6589063ef63ba8acdee86fcb9f395"
+  integrity sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==
+
 "@babel/cli@^7.5.5":
   version "7.10.5"
   resolved "https://registry.npmjs.org/@babel/cli/-/cli-7.10.5.tgz"
@@ -1718,6 +2219,11 @@
     google-protobuf "3.11.4"
     parsimmon "1.6.2"
 
+"@nodable/entities@2.1.0", "@nodable/entities@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@nodable/entities/-/entities-2.1.0.tgz#f543e5c6446720d4cf9e498a83019dd159973bc2"
+  integrity sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==
+
 "@npmcli/fs@^1.0.0":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@npmcli/fs/-/fs-1.1.1.tgz#72f719fe935e687c56a4faecf3c03d06ba593257"
@@ -1843,6 +2349,402 @@
   integrity sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==
   dependencies:
     "@sinonjs/commons" "^1.7.0"
+
+"@smithy/config-resolver@^4.4.17":
+  version "4.4.17"
+  resolved "https://registry.yarnpkg.com/@smithy/config-resolver/-/config-resolver-4.4.17.tgz#5bd7ccf461e126c79072ce84c6b0f3d00b3409bc"
+  integrity sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==
+  dependencies:
+    "@smithy/node-config-provider" "^4.3.14"
+    "@smithy/types" "^4.14.1"
+    "@smithy/util-config-provider" "^4.2.2"
+    "@smithy/util-endpoints" "^3.4.2"
+    "@smithy/util-middleware" "^4.2.14"
+    tslib "^2.6.2"
+
+"@smithy/core@^3.23.17":
+  version "3.23.17"
+  resolved "https://registry.yarnpkg.com/@smithy/core/-/core-3.23.17.tgz#23d02277c8d6d30a1605afd756696265e48ed67e"
+  integrity sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==
+  dependencies:
+    "@smithy/protocol-http" "^5.3.14"
+    "@smithy/types" "^4.14.1"
+    "@smithy/url-parser" "^4.2.14"
+    "@smithy/util-base64" "^4.3.2"
+    "@smithy/util-body-length-browser" "^4.2.2"
+    "@smithy/util-middleware" "^4.2.14"
+    "@smithy/util-stream" "^4.5.25"
+    "@smithy/util-utf8" "^4.2.2"
+    "@smithy/uuid" "^1.1.2"
+    tslib "^2.6.2"
+
+"@smithy/credential-provider-imds@^4.2.14":
+  version "4.2.14"
+  resolved "https://registry.yarnpkg.com/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz#b5dcc198ee240eaf68069e7449bcec29ce279827"
+  integrity sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==
+  dependencies:
+    "@smithy/node-config-provider" "^4.3.14"
+    "@smithy/property-provider" "^4.2.14"
+    "@smithy/types" "^4.14.1"
+    "@smithy/url-parser" "^4.2.14"
+    tslib "^2.6.2"
+
+"@smithy/fetch-http-handler@^5.3.17":
+  version "5.3.17"
+  resolved "https://registry.yarnpkg.com/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz#bf13a4b03eb8afe101775fef59a1758f8fb5cd4b"
+  integrity sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==
+  dependencies:
+    "@smithy/protocol-http" "^5.3.14"
+    "@smithy/querystring-builder" "^4.2.14"
+    "@smithy/types" "^4.14.1"
+    "@smithy/util-base64" "^4.3.2"
+    tslib "^2.6.2"
+
+"@smithy/hash-node@^4.2.14":
+  version "4.2.14"
+  resolved "https://registry.yarnpkg.com/@smithy/hash-node/-/hash-node-4.2.14.tgz#e3ed33dc614e26fff5f043e097750c6931b48592"
+  integrity sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==
+  dependencies:
+    "@smithy/types" "^4.14.1"
+    "@smithy/util-buffer-from" "^4.2.2"
+    "@smithy/util-utf8" "^4.2.2"
+    tslib "^2.6.2"
+
+"@smithy/invalid-dependency@^4.2.14":
+  version "4.2.14"
+  resolved "https://registry.yarnpkg.com/@smithy/invalid-dependency/-/invalid-dependency-4.2.14.tgz#a52766f9d4299abcd9d6cd23b5a76f34fc59c7a0"
+  integrity sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==
+  dependencies:
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@smithy/is-array-buffer@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz#f84f0d9f9a36601a9ca9381688bd1b726fd39111"
+  integrity sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/is-array-buffer@^4.2.2":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz#c401ce54b12a16529eb1c938a0b6c2247cb763b8"
+  integrity sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/middleware-content-length@^4.2.14":
+  version "4.2.14"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-content-length/-/middleware-content-length-4.2.14.tgz#d8b17f94c4d8f9c3b7992f1db84d3299c83efe78"
+  integrity sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==
+  dependencies:
+    "@smithy/protocol-http" "^5.3.14"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@smithy/middleware-endpoint@^4.4.32":
+  version "4.4.32"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.32.tgz#4c7dcf06b637b40dfcc53d3b18d1a784a747c530"
+  integrity sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==
+  dependencies:
+    "@smithy/core" "^3.23.17"
+    "@smithy/middleware-serde" "^4.2.20"
+    "@smithy/node-config-provider" "^4.3.14"
+    "@smithy/shared-ini-file-loader" "^4.4.9"
+    "@smithy/types" "^4.14.1"
+    "@smithy/url-parser" "^4.2.14"
+    "@smithy/util-middleware" "^4.2.14"
+    tslib "^2.6.2"
+
+"@smithy/middleware-retry@^4.5.7":
+  version "4.5.7"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-retry/-/middleware-retry-4.5.7.tgz#a2da0c472d631ee408ff566186c99571b3efb70b"
+  integrity sha512-bRt6ZImqVSeTk39Nm81K20ObIiAZ3WefY7G6+iz/0tZjs4dgRRjvRX2sgsH+zi6iDCRR/aQvQofLKxxz4rPBZg==
+  dependencies:
+    "@smithy/core" "^3.23.17"
+    "@smithy/node-config-provider" "^4.3.14"
+    "@smithy/protocol-http" "^5.3.14"
+    "@smithy/service-error-classification" "^4.3.1"
+    "@smithy/smithy-client" "^4.12.13"
+    "@smithy/types" "^4.14.1"
+    "@smithy/util-middleware" "^4.2.14"
+    "@smithy/util-retry" "^4.3.6"
+    "@smithy/uuid" "^1.1.2"
+    tslib "^2.6.2"
+
+"@smithy/middleware-serde@^4.2.20":
+  version "4.2.20"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-serde/-/middleware-serde-4.2.20.tgz#76862c8f9b39b08501539440a2e6bca7a77de508"
+  integrity sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==
+  dependencies:
+    "@smithy/core" "^3.23.17"
+    "@smithy/protocol-http" "^5.3.14"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@smithy/middleware-stack@^4.2.14":
+  version "4.2.14"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-stack/-/middleware-stack-4.2.14.tgz#23a4cf643ccdbde52c8780fe5cc080611efef1c7"
+  integrity sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==
+  dependencies:
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@smithy/node-config-provider@^4.3.14":
+  version "4.3.14"
+  resolved "https://registry.yarnpkg.com/@smithy/node-config-provider/-/node-config-provider-4.3.14.tgz#8ca13b86b6123cbb0425d669bd847fcd333ca4bd"
+  integrity sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==
+  dependencies:
+    "@smithy/property-provider" "^4.2.14"
+    "@smithy/shared-ini-file-loader" "^4.4.9"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@smithy/node-http-handler@^4.6.1":
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/@smithy/node-http-handler/-/node-http-handler-4.6.1.tgz#cb25b9445e46294a6f0dfb1566dbf2a1a19510af"
+  integrity sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==
+  dependencies:
+    "@smithy/protocol-http" "^5.3.14"
+    "@smithy/querystring-builder" "^4.2.14"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@smithy/property-provider@^4.2.14":
+  version "4.2.14"
+  resolved "https://registry.yarnpkg.com/@smithy/property-provider/-/property-provider-4.2.14.tgz#8072418672d8c29d3f9ef35e452437ba2c59100a"
+  integrity sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==
+  dependencies:
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@smithy/protocol-http@^5.3.14":
+  version "5.3.14"
+  resolved "https://registry.yarnpkg.com/@smithy/protocol-http/-/protocol-http-5.3.14.tgz#ed1e65cdb0fffb7fd00dce997c04baa236f180cc"
+  integrity sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==
+  dependencies:
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@smithy/querystring-builder@^4.2.14":
+  version "4.2.14"
+  resolved "https://registry.yarnpkg.com/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz#102429e0fb004108babf219edfcf6f111e66d782"
+  integrity sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==
+  dependencies:
+    "@smithy/types" "^4.14.1"
+    "@smithy/util-uri-escape" "^4.2.2"
+    tslib "^2.6.2"
+
+"@smithy/querystring-parser@^4.2.14":
+  version "4.2.14"
+  resolved "https://registry.yarnpkg.com/@smithy/querystring-parser/-/querystring-parser-4.2.14.tgz#c479ba1f346656b9f8ce46d9a91c229e4e50420f"
+  integrity sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==
+  dependencies:
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@smithy/service-error-classification@^4.3.1":
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/@smithy/service-error-classification/-/service-error-classification-4.3.1.tgz#5303d4fc3c3eea0f79c3b88cb4436498a31e9f12"
+  integrity sha512-aUQuDGh760ts/8MU+APjIZhlLPKhIIfqyzZaJikLEIMrdxFvxuLYD0WxWzaYWpmLbQlXDe9p7EWM3HsBe0K6Gw==
+  dependencies:
+    "@smithy/types" "^4.14.1"
+
+"@smithy/shared-ini-file-loader@^4.4.9":
+  version "4.4.9"
+  resolved "https://registry.yarnpkg.com/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.9.tgz#fb3719b401d101a65a682380b40efd3a116162f0"
+  integrity sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==
+  dependencies:
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@smithy/signature-v4@^5.3.14":
+  version "5.3.14"
+  resolved "https://registry.yarnpkg.com/@smithy/signature-v4/-/signature-v4-5.3.14.tgz#2b28c7d190301a67a520227a2343d1e7bb1c6d22"
+  integrity sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==
+  dependencies:
+    "@smithy/is-array-buffer" "^4.2.2"
+    "@smithy/protocol-http" "^5.3.14"
+    "@smithy/types" "^4.14.1"
+    "@smithy/util-hex-encoding" "^4.2.2"
+    "@smithy/util-middleware" "^4.2.14"
+    "@smithy/util-uri-escape" "^4.2.2"
+    "@smithy/util-utf8" "^4.2.2"
+    tslib "^2.6.2"
+
+"@smithy/smithy-client@^4.12.13":
+  version "4.12.13"
+  resolved "https://registry.yarnpkg.com/@smithy/smithy-client/-/smithy-client-4.12.13.tgz#dec184a1d2d5027370ae1582bddbdbc068c97da5"
+  integrity sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==
+  dependencies:
+    "@smithy/core" "^3.23.17"
+    "@smithy/middleware-endpoint" "^4.4.32"
+    "@smithy/middleware-stack" "^4.2.14"
+    "@smithy/protocol-http" "^5.3.14"
+    "@smithy/types" "^4.14.1"
+    "@smithy/util-stream" "^4.5.25"
+    tslib "^2.6.2"
+
+"@smithy/types@^4.14.1":
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/@smithy/types/-/types-4.14.1.tgz#aba92b4cdb406f2a2b062e82f1e3728d809a7c23"
+  integrity sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/url-parser@^4.2.14":
+  version "4.2.14"
+  resolved "https://registry.yarnpkg.com/@smithy/url-parser/-/url-parser-4.2.14.tgz#349a442a62eb5907533f204b73a010618198b073"
+  integrity sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==
+  dependencies:
+    "@smithy/querystring-parser" "^4.2.14"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@smithy/util-base64@^4.3.2":
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/@smithy/util-base64/-/util-base64-4.3.2.tgz#be02bcb29a87be744356467ea25ffa413e695cea"
+  integrity sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==
+  dependencies:
+    "@smithy/util-buffer-from" "^4.2.2"
+    "@smithy/util-utf8" "^4.2.2"
+    tslib "^2.6.2"
+
+"@smithy/util-body-length-browser@^4.2.2":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz#c4404277d22039872abdb80e7800f9a63f263862"
+  integrity sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/util-body-length-node@^4.2.3":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz#f923ca530defb86a9ac3ca2d3066bcca7b304fbc"
+  integrity sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/util-buffer-from@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz#6fc88585165ec73f8681d426d96de5d402021e4b"
+  integrity sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==
+  dependencies:
+    "@smithy/is-array-buffer" "^2.2.0"
+    tslib "^2.6.2"
+
+"@smithy/util-buffer-from@^4.2.2":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz#2c6b7857757dfd88f6cd2d36016179a40ccc913b"
+  integrity sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==
+  dependencies:
+    "@smithy/is-array-buffer" "^4.2.2"
+    tslib "^2.6.2"
+
+"@smithy/util-config-provider@^4.2.2":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz#52ebf9d8942838d18bc5fb1520de1e8699d7aad6"
+  integrity sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/util-defaults-mode-browser@^4.3.49":
+  version "4.3.49"
+  resolved "https://registry.yarnpkg.com/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.49.tgz#926ce84bf65e56307f25cce7a13b427d33442939"
+  integrity sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==
+  dependencies:
+    "@smithy/property-provider" "^4.2.14"
+    "@smithy/smithy-client" "^4.12.13"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@smithy/util-defaults-mode-node@^4.2.54":
+  version "4.2.54"
+  resolved "https://registry.yarnpkg.com/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.54.tgz#32c4ea9f8a8c74ef9fe0ca5e3d6a10df0327f87e"
+  integrity sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==
+  dependencies:
+    "@smithy/config-resolver" "^4.4.17"
+    "@smithy/credential-provider-imds" "^4.2.14"
+    "@smithy/node-config-provider" "^4.3.14"
+    "@smithy/property-provider" "^4.2.14"
+    "@smithy/smithy-client" "^4.12.13"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@smithy/util-endpoints@^3.4.2":
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/@smithy/util-endpoints/-/util-endpoints-3.4.2.tgz#ee59c42d039a642b6c6eb2d38e0ae3db6fc48e97"
+  integrity sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==
+  dependencies:
+    "@smithy/node-config-provider" "^4.3.14"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@smithy/util-hex-encoding@^4.2.2":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz#4abf3335dd1eb884041d8589ca7628d81a6fd1d3"
+  integrity sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/util-middleware@^4.2.14":
+  version "4.2.14"
+  resolved "https://registry.yarnpkg.com/@smithy/util-middleware/-/util-middleware-4.2.14.tgz#9985dd82b4036db2d03835229b9b0c63d2bb85fa"
+  integrity sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==
+  dependencies:
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@smithy/util-retry@^4.3.6":
+  version "4.3.8"
+  resolved "https://registry.yarnpkg.com/@smithy/util-retry/-/util-retry-4.3.8.tgz#7f904ed8e5bad2b5f2e6aa1e193db2b46b2c57df"
+  integrity sha512-LUIxbTBi+OpvXpg91poGA6BdyoleMDLnfXjVDqyi2RvZmTveY5loE/FgYUBCR5LU2BThW2SoZRh8dTIIy38IPw==
+  dependencies:
+    "@smithy/service-error-classification" "^4.3.1"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@smithy/util-stream@^4.5.25":
+  version "4.5.25"
+  resolved "https://registry.yarnpkg.com/@smithy/util-stream/-/util-stream-4.5.25.tgz#f48385a284151c7e099395af4e5fb0978fffe4ff"
+  integrity sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==
+  dependencies:
+    "@smithy/fetch-http-handler" "^5.3.17"
+    "@smithy/node-http-handler" "^4.6.1"
+    "@smithy/types" "^4.14.1"
+    "@smithy/util-base64" "^4.3.2"
+    "@smithy/util-buffer-from" "^4.2.2"
+    "@smithy/util-hex-encoding" "^4.2.2"
+    "@smithy/util-utf8" "^4.2.2"
+    tslib "^2.6.2"
+
+"@smithy/util-uri-escape@^4.2.2":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz#48e40206e7fe9daefc8d44bb43a1ab17e76abf4a"
+  integrity sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/util-utf8@^2.0.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-utf8/-/util-utf8-2.3.0.tgz#dd96d7640363259924a214313c3cf16e7dd329c5"
+  integrity sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==
+  dependencies:
+    "@smithy/util-buffer-from" "^2.2.0"
+    tslib "^2.6.2"
+
+"@smithy/util-utf8@^4.2.2":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@smithy/util-utf8/-/util-utf8-4.2.2.tgz#21db686982e6f3393ac262e49143b42370130f13"
+  integrity sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==
+  dependencies:
+    "@smithy/util-buffer-from" "^4.2.2"
+    tslib "^2.6.2"
+
+"@smithy/uuid@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@smithy/uuid/-/uuid-1.1.2.tgz#b6e97c7158615e4a3c775e809c00d8c269b5a12e"
+  integrity sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==
+  dependencies:
+    tslib "^2.6.2"
 
 "@sqltools/log@latest":
   version "1.0.3"
@@ -2643,6 +3545,11 @@ boolbase@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
+
+bowser@^2.11.0:
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.14.1.tgz#4ea39bf31e305184522d7ad7bfd91389e4f0cb79"
+  integrity sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -4093,6 +5000,23 @@ fast-safe-stringify@^2.0.7:
   version "2.0.7"
   resolved "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz"
   integrity sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==
+
+fast-xml-builder@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz#50188e1452a5fa095f415d3e63dcac0a1dbcbf11"
+  integrity sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==
+  dependencies:
+    path-expression-matcher "^1.1.3"
+
+fast-xml-parser@5.7.2:
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz#fecd0b054c6c132fc03dab994a413da781e0eb9f"
+  integrity sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==
+  dependencies:
+    "@nodable/entities" "^2.1.0"
+    fast-xml-builder "^1.1.5"
+    path-expression-matcher "^1.5.0"
+    strnum "^2.2.3"
 
 fb-watchman@^2.0.0:
   version "2.0.1"
@@ -6742,6 +7666,11 @@ path-exists@^4.0.0:
   resolved "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
+path-expression-matcher@^1.1.3, path-expression-matcher@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz#3b98545dc88ffebb593e2d8458d0929da9275f4a"
+  integrity sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==
+
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
@@ -8088,6 +9017,11 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
 
+strnum@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/strnum/-/strnum-2.2.3.tgz#0119fce02749a11bb126a4d686ac5dbdf6e57586"
+  integrity sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==
+
 supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz"
@@ -8357,6 +9291,11 @@ tslib@^1.9.0, tslib@^1.9.3:
   version "1.13.0"
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
+
+tslib@^2.6.2:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tunnel-agent@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
## Description

Adds **IAM database authentication** for Amazon RDS / Aurora to the PostgreSQL and MySQL drivers.

Users can now connect to RDS/Aurora without storing a DB password. Instead, the driver signs a short-lived (15 min) IAM auth token using the AWS SDK's RDS Signer and passes it as the password. Credentials come from the user's normal AWS credential provider chain (env vars, shared config profile, IMDS, SSO, etc.); an optional AWS profile name can be provided to target a specific set of credentials.

### What's new

- New **Password mode: "IAM database authentication"** in both the PostgreSQL and MySQL connection forms.
- **AWS Region** (required) and **AWS Profile** (optional) fields appear when IAM mode is selected.
- **SSL is required** when IAM auth is enabled (token must be transmitted over TLS). A clear error is raised if SSL isn't configured.
- **PostgreSQL**: uses pg's async password callback so every new pool connection gets a freshly-signed token, keeping long-lived pools working past the 15-minute token expiry.
- **MySQL**: mysql2 doesn't support async password callbacks, so a single token is used for the pool's lifetime. Users reconnect to refresh after expiry. This limitation is documented in the driver README.

### Architectural notes

- The AWS SDK lives inside each driver package (not in the main SQLTools extension), so users of other drivers pay nothing for this feature.
- `parseBeforeSaveConnection` / `parseBeforeEditConnection` were refactored into a declarative `PASSWORD_MODES` table. Each entry declares which properties a mode "owns", making it structurally impossible to forget cleanup branches when switching modes.

### Tests

- Unit tests for the connection parser (save/edit round-trip across all modes) and JSON schema validation (valid/invalid IAM configurations).
- Integration-style tests for each driver's `open()` IAM path with the AWS SDK mocked: pool password callback wiring, region/SSL/host validation, non-IAM happy path regression.
- 89 new tests in total, 330 tests passing overall.

### Docs

- Each driver's README gains an "IAM database authentication" section with setup steps, a pointer to the AWS RDS CA bundle, and an example `GRANT rds_iam` statement (PostgreSQL) or `CREATE USER ... AWSAuthenticationPlugin` (MySQL).

### Out of scope

- Other drivers (MSSQL, SQLite): MSSQL uses Entra ID (a different flow); SQLite is not networked.
- Driver for AWS Redshift: can be added with the same pattern if there's demand.

---

- [x] Your code builds clean without any errors or warnings
- [x] You have made the needed changes to the docs
- [x] You have written a description of what is the purpose of this pull request above
