### PR TITLE
feat: Add ER diagram visualization for database schemas

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,9 @@
     "source-map-support": "^0.5.11",
     "typescript": "~4.8.3",
     "@vscode/vsce": "^2.19.0",
-    "ts-node": "^9.1.1"
+    "ts-node": "^9.1.1",
+    "react-flow-renderer": "^10.3.17",
+    "dagre": "^0.8.5",
+    "@types/dagre": "^0.7.52"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,9 @@
     "driver:pack:mssql": "(cd packages/driver.mssql/ && yarn run package && mv *.vsix '../../.')",
     "driver:pack:sqlite": "(cd packages/driver.sqlite/ && yarn run package && mv *.vsix '../../.')"
   },
+  "resolutions": {
+    "@types/d3-dispatch": "3.0.5"
+  },
   "devDependencies": {
     "@types/source-map-support": "^0.5.0",
     "cross-env": "^7.0.2",

--- a/packages/base-driver/src/index.ts
+++ b/packages/base-driver/src/index.ts
@@ -120,6 +120,24 @@ export default abstract class AbstractDriver<ConnectionType extends any, DriverO
     return Promise.resolve("");
   }
 
+  public async getERDiagramData(schema: NSDatabase.ISchema): Promise<{ tables: NSDatabase.ITable[], columns: { [tableName: string]: NSDatabase.IColumn[] }, foreignKeys: NSDatabase.IForeignKey[] }> {
+    const tables: NSDatabase.ITable[] = await this.queryResults(this.queries.fetchTables(schema));
+    const columns: { [tableName: string]: NSDatabase.IColumn[] } = {};
+    for (const table of tables) {
+      const cols: NSDatabase.IColumn[] = await this.queryResults(this.queries.fetchColumns(table));
+      columns[table.label] = cols;
+    }
+    let foreignKeys: NSDatabase.IForeignKey[] = [];
+    if (this.queries.fetchForeignKeys) {
+      try {
+        foreignKeys = await this.queryResults(this.queries.fetchForeignKeys(schema));
+      } catch (e) {
+        this.log.warn('Failed to fetch foreign keys: %O', e);
+      }
+    }
+    return { tables, columns, foreignKeys };
+  }
+
   public async toAbsolutePath(fsPath: string) {
     if (!path.isAbsolute(fsPath) && /\$\{workspaceFolder:(.+)}/g.test(fsPath)) {
       const workspaceName = fsPath.match(/\$\{workspaceFolder:(.+)}/)[1];

--- a/packages/base-driver/src/lib/factory.test.ts
+++ b/packages/base-driver/src/lib/factory.test.ts
@@ -17,5 +17,44 @@ describe(`query generator`, () => {
 
     const expected = `SELECT * FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'table' AND TABLE_CATALOG = 'catalog' AND TABLE_SCHEMA = 'schema' AND something = 'smtg'`;
     expect(result).toBe(expected);
-  })
+  });
+
+  it(`should generate foreign key queries with schema and database params`, () => {
+    const fetchForeignKeys = queryFactory<{ schema: string; database: string }>`
+    SELECT
+      tc.constraint_name AS "constraintName",
+      tc.table_schema AS "sourceTableSchema",
+      tc.table_name AS "sourceTableName",
+      kcu.column_name AS "sourceColumnName",
+      ccu.table_schema AS "targetTableSchema",
+      ccu.table_name AS "targetTableName",
+      ccu.column_name AS "targetColumnName"
+    FROM information_schema.table_constraints AS tc
+    WHERE
+      tc.constraint_type = 'FOREIGN KEY'
+      AND tc.table_schema = '${p => p.schema}'
+      AND tc.table_catalog = '${p => p.database}'
+    `;
+    const result = fetchForeignKeys({ schema: 'public', database: 'mydb' });
+
+    expect(result).toContain("tc.table_schema = 'public'");
+    expect(result).toContain("tc.table_catalog = 'mydb'");
+    expect(result).toContain("tc.constraint_type = 'FOREIGN KEY'");
+    expect(result).toContain('"constraintName"');
+    expect(result).toContain('"sourceTableName"');
+    expect(result).toContain('"targetTableName"');
+  });
+
+  it(`should handle queries with no dynamic params`, () => {
+    const staticQuery = queryFactory`SELECT 1 AS result`;
+    expect(staticQuery({})).toBe('SELECT 1 AS result');
+  });
+
+  it(`should expose raw query template`, () => {
+    const query = queryFactory<{ name: string }>`
+    SELECT * FROM tables WHERE name = '${p => p.name}'
+    `;
+    expect(query.raw).toBeDefined();
+    expect(query.raw).toContain('${');
+  });
 });

--- a/packages/base-driver/tsconfig.json
+++ b/packages/base-driver/tsconfig.json
@@ -12,6 +12,7 @@
     "resolveJsonModule": true,
     "sourceMap": false,
     "declaration": true,
+    "skipLibCheck": true,
     "target": "es6",
     "outDir": "./dist"
   },

--- a/packages/driver.mssql/src/ls/queries.ts
+++ b/packages/driver.mssql/src/ls/queries.ts
@@ -699,3 +699,30 @@ WHERE 1=1
   AND tr.name = '${item => item.label}'
   AND tr.parent_class ${item => item.parent && item.parent.type === ContextValue.DATABASE ? '=' : '!=' } 0
 `;
+
+export const fetchForeignKeys: IBaseQueries['fetchForeignKeys'] = queryFactory`
+SELECT
+  FK.CONSTRAINT_NAME AS "constraintName",
+  FK.TABLE_SCHEMA AS "sourceTableSchema",
+  FK.TABLE_NAME AS "sourceTableName",
+  CU.COLUMN_NAME AS "sourceColumnName",
+  PK.TABLE_SCHEMA AS "targetTableSchema",
+  PK.TABLE_NAME AS "targetTableName",
+  PT.COLUMN_NAME AS "targetColumnName"
+FROM
+  ${p => p.database ? `${escapeTableName({ database: p.database, schema: "INFORMATION_SCHEMA", label: "REFERENTIAL_CONSTRAINTS" })}` : 'INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS'} AS C
+  JOIN ${p => p.database ? `${escapeTableName({ database: p.database, schema: "INFORMATION_SCHEMA", label: "TABLE_CONSTRAINTS" })}` : 'INFORMATION_SCHEMA.TABLE_CONSTRAINTS'} AS FK
+    ON C.CONSTRAINT_NAME = FK.CONSTRAINT_NAME AND C.CONSTRAINT_SCHEMA = FK.CONSTRAINT_SCHEMA
+  JOIN ${p => p.database ? `${escapeTableName({ database: p.database, schema: "INFORMATION_SCHEMA", label: "TABLE_CONSTRAINTS" })}` : 'INFORMATION_SCHEMA.TABLE_CONSTRAINTS'} AS PK
+    ON C.UNIQUE_CONSTRAINT_NAME = PK.CONSTRAINT_NAME AND C.UNIQUE_CONSTRAINT_SCHEMA = PK.CONSTRAINT_SCHEMA
+  JOIN ${p => p.database ? `${escapeTableName({ database: p.database, schema: "INFORMATION_SCHEMA", label: "KEY_COLUMN_USAGE" })}` : 'INFORMATION_SCHEMA.KEY_COLUMN_USAGE'} AS CU
+    ON C.CONSTRAINT_NAME = CU.CONSTRAINT_NAME AND C.CONSTRAINT_SCHEMA = CU.CONSTRAINT_SCHEMA
+  JOIN ${p => p.database ? `${escapeTableName({ database: p.database, schema: "INFORMATION_SCHEMA", label: "KEY_COLUMN_USAGE" })}` : 'INFORMATION_SCHEMA.KEY_COLUMN_USAGE'} AS PT
+    ON C.UNIQUE_CONSTRAINT_NAME = PT.CONSTRAINT_NAME AND C.UNIQUE_CONSTRAINT_SCHEMA = PT.CONSTRAINT_SCHEMA
+WHERE
+  FK.TABLE_SCHEMA = '${p => p.schema}'
+  AND FK.TABLE_CATALOG = '${p => p.database}'
+ORDER BY
+  FK.TABLE_NAME,
+  CU.COLUMN_NAME
+`;

--- a/packages/driver.mysql/src/ls/queries.ts
+++ b/packages/driver.mysql/src/ls/queries.ts
@@ -296,3 +296,22 @@ SHOW CREATE PROCEDURE \`${item => item.label}\`
 export const fetchTriggerDefinition: IBaseQueries['fetchTriggerDefinition'] = queryFactory`
 SHOW CREATE TRIGGER \`${item => item.label}\`
 `;
+
+export const fetchForeignKeys: IBaseQueries['fetchForeignKeys'] = queryFactory`
+SELECT
+  KCU.CONSTRAINT_NAME AS "constraintName",
+  KCU.TABLE_SCHEMA AS "sourceTableSchema",
+  KCU.TABLE_NAME AS "sourceTableName",
+  KCU.COLUMN_NAME AS "sourceColumnName",
+  KCU.REFERENCED_TABLE_SCHEMA AS "targetTableSchema",
+  KCU.REFERENCED_TABLE_NAME AS "targetTableName",
+  KCU.REFERENCED_COLUMN_NAME AS "targetColumnName"
+FROM
+  INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS KCU
+WHERE
+  KCU.REFERENCED_TABLE_NAME IS NOT NULL
+  AND KCU.TABLE_SCHEMA = '${p => p.schema}'
+ORDER BY
+  KCU.TABLE_NAME,
+  KCU.COLUMN_NAME
+`;

--- a/packages/driver.pg/src/ls/driver.ts
+++ b/packages/driver.pg/src/ls/driver.ts
@@ -127,12 +127,15 @@ export default class PostgreSQL extends AbstractDriver<Pool, PoolConfig> impleme
   public query: (typeof AbstractDriver)['prototype']['query'] = (query, opt = {}) => {
     const messages = [];
     let cli : PoolClient;
+    let noticeHandler: (notice: any) => void;
     const { requestId } = opt;
     return this.open()
       .then(async (pool) => {
         cli = await pool.connect();
-        cli.on('notice', notice => messages.push(this.prepareMessage(`${notice.name.toUpperCase()}: ${notice.message}`)));
+        noticeHandler = notice => messages.push(this.prepareMessage(`${notice.name.toUpperCase()}: ${notice.message}`));
+        cli.on('notice', noticeHandler);
         const results = await cli.query({ text: query.toString(), rowMode: 'array' });
+        cli.removeListener('notice', noticeHandler);
         cli.release();
         return results;
       })
@@ -160,6 +163,7 @@ export default class PostgreSQL extends AbstractDriver<Pool, PoolConfig> impleme
         });
       })
       .catch(err => {
+        if (cli && noticeHandler) cli.removeListener('notice', noticeHandler);
         cli && cli.release();
         return [<NSDatabase.IResult>{
           connId: this.getId(),

--- a/packages/driver.pg/src/ls/queries.ts
+++ b/packages/driver.pg/src/ls/queries.ts
@@ -445,6 +445,31 @@ WHERE tr.evtname = '${item.label}'
 }`;
 
 
+const fetchForeignKeys: IBaseQueries['fetchForeignKeys'] = queryFactory`
+SELECT
+  tc.constraint_name AS "constraintName",
+  tc.table_schema AS "sourceTableSchema",
+  tc.table_name AS "sourceTableName",
+  kcu.column_name AS "sourceColumnName",
+  ccu.table_schema AS "targetTableSchema",
+  ccu.table_name AS "targetTableName",
+  ccu.column_name AS "targetColumnName"
+FROM information_schema.table_constraints AS tc
+JOIN information_schema.key_column_usage AS kcu
+  ON tc.constraint_name = kcu.constraint_name
+  AND tc.table_schema = kcu.table_schema
+JOIN information_schema.constraint_column_usage AS ccu
+  ON ccu.constraint_name = tc.constraint_name
+  AND ccu.table_schema = tc.table_schema
+WHERE
+  tc.constraint_type = 'FOREIGN KEY'
+  AND tc.table_schema = '${p => p.schema}'
+  AND tc.table_catalog = '${p => p.database}'
+ORDER BY
+  tc.table_name,
+  kcu.column_name
+`;
+
 export default {
   describeTable,
   countRecords,
@@ -467,5 +492,6 @@ export default {
   fetchFunctionDefinition,
   fetchProcedureDefinition,
   fetchIndexDefinition,
-  fetchTriggerDefinition
+  fetchTriggerDefinition,
+  fetchForeignKeys
 };

--- a/packages/driver.sqlite/src/ls/queries.ts
+++ b/packages/driver.sqlite/src/ls/queries.ts
@@ -85,6 +85,22 @@ ORDER BY C.name ASC,
 LIMIT ${p => p.limit || 100}
 `;
 
+const fetchForeignKeys: IBaseQueries['fetchForeignKeys'] = queryFactory`
+SELECT
+  '' AS "constraintName",
+  '' AS "sourceTableSchema",
+  m.name AS "sourceTableName",
+  fk."from" AS "sourceColumnName",
+  '' AS "targetTableSchema",
+  fk."table" AS "targetTableName",
+  fk."to" AS "targetColumnName"
+FROM sqlite_master AS m
+JOIN pragma_foreign_key_list(m.name) AS fk ON 1 = 1
+WHERE m.type = 'table'
+  AND m.name NOT LIKE 'sqlite_%'
+ORDER BY m.name, fk.seq
+`;
+
 const searchIndexes: IBaseQueries['searchIndexes'] = queryFactory`
 SELECT
   '${ContextValue.INDEX}' AS "type",
@@ -168,7 +184,8 @@ export default {
   fetchTableDefinition,
   fetchViewDefinition,
   fetchIndexDefinition,
-  fetchTriggerDefinition
+  fetchTriggerDefinition,
+  fetchForeignKeys
 }
 
 // export default {

--- a/packages/extension/build.json
+++ b/packages/extension/build.json
@@ -16,6 +16,7 @@
       "entries": {
         "Settings": "../plugins/connection-manager/webview/ui/screens/Settings/index.tsx",
         "Results": "../plugins/connection-manager/webview/ui/screens/Results/index.tsx",
+        "ERDiagram": "../plugins/connection-manager/webview/ui/screens/ERDiagram/index.tsx",
         "theme": "../plugins/connection-manager/webview/ui/sass/theme.scss"
       },
       "type": "webview"

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -362,6 +362,15 @@
                 "title": "Open Docs",
                 "command": "sqltools.openDocs",
                 "category": "SQLTools"
+            },
+            {
+                "title": "Show ER Diagram",
+                "command": "sqltools.showERDiagram",
+                "category": "SQLTools Connection",
+                "icon": {
+                    "light": "icons/show-light.svg",
+                    "dark": "icons/show-dark.svg"
+                }
             }
         ],
         "keybindings": [
@@ -1056,6 +1065,10 @@
                     "when": "false"
                 },
                 {
+                    "command": "sqltools.showERDiagram",
+                    "when": "false"
+                },
+                {
                     "command": "sqltools.generateInsertQuery",
                     "when": "false"
                 },
@@ -1158,6 +1171,11 @@
                 {
                     "command": "sqltools.showRecords",
                     "when": "view == sqltoolsViewConnectionExplorer && viewItem =~ /^connection\\.(table|view|materializedView)$/",
+                    "group": "navigation@1"
+                },
+                {
+                    "command": "sqltools.showERDiagram",
+                    "when": "view == sqltoolsViewConnectionExplorer && viewItem == connection.schema",
                     "group": "navigation@1"
                 },
                 {

--- a/packages/formatter/tsconfig.json
+++ b/packages/formatter/tsconfig.json
@@ -12,6 +12,7 @@
       "outDir": "./lib",
       "sourceMap": false,
       "declaration": true,
+      "skipLibCheck": true,
       "target": "ES3",
       "rootDir": "src",
     },

--- a/packages/language-server/src/connection.ts
+++ b/packages/language-server/src/connection.ts
@@ -176,6 +176,13 @@ export default class Connection {
     return insertQuery;
   }
 
+  public async getERDiagramData(schema: NSDatabase.ISchema) {
+    if (this.conn.getERDiagramData && typeof this.conn.getERDiagramData === 'function') {
+      return this.conn.getERDiagramData(schema);
+    }
+    return { tables: [], columns: {}, foreignKeys: [] };
+  }
+
   public searchItems(itemType: ContextValue, search: string = '', extraParams = {}) {
     return this.conn.searchItems(itemType, search, extraParams);
   }

--- a/packages/plugins/connection-manager/contracts.ts
+++ b/packages/plugins/connection-manager/contracts.ts
@@ -88,6 +88,13 @@ export const GetInsertQueryRequest = new RequestType<
   void
 >('connection/GetInsertQueryRequest');
 
+export const GetERDiagramDataRequest = new RequestType<
+  { conn: IConnection, schema: NSDatabase.ISchema },
+  { tables: NSDatabase.ITable[], columns: { [tableName: string]: NSDatabase.IColumn[] }, foreignKeys: NSDatabase.IForeignKey[] },
+  Error,
+  void
+>('connection/GetERDiagramDataRequest');
+
 
 // @OPTIMIZE: later this will be replace by the native library when available
 export interface ProgressNotificationStartParams {

--- a/packages/plugins/connection-manager/extension.ts
+++ b/packages/plugins/connection-manager/extension.ts
@@ -1,6 +1,7 @@
 import { ConnectionExplorer, SidebarConnection, SidebarItem } from '@sqltools/plugins/connection-manager/explorer';
 import ResultsWebviewManager from '@sqltools/plugins/connection-manager/webview/results';
 import SettingsWebview from '@sqltools/plugins/connection-manager/webview/settings';
+import ERDiagramWebview from '@sqltools/plugins/connection-manager/webview/er-diagram';
 import { ContextValue, IConnection, IExtension, IExtensionPlugin, ILanguageClient, IQueryOptions, NSDatabase, RequestHandler } from '@sqltools/types';
 import Config from '@sqltools/util/config-manager';
 import { getConnectionDescription, getConnectionId, getSessionBasename, migrateConnectionSettings } from '@sqltools/util/connection';
@@ -19,7 +20,7 @@ import { promises as fs } from 'fs';
 import { file } from 'tempy';
 import { CancellationTokenSource, commands, ConfigurationTarget, env as vscodeEnv, Progress, ProgressLocation, QuickPickItem, TextDocument, TextEditor, ThemeIcon, Uri, window, workspace } from 'vscode';
 import CodeLensPlugin from '../codelens/extension';
-import { ConnectRequest, DisconnectRequest, ForceListRefresh, GetChildrenForTreeItemRequest, GetConnectionPasswordRequest, GetConnectionsRequest, GetInsertQueryRequest, GetDefinitionQueryForItemRequest, ProgressNotificationComplete, ProgressNotificationCompleteParams, ProgressNotificationStart, ProgressNotificationStartParams, ReleaseResultsRequest, RunCommandRequest, GetResultsRequest, SearchConnectionItemsRequest, TestConnectionRequest } from './contracts';
+import { ConnectRequest, DisconnectRequest, ForceListRefresh, GetChildrenForTreeItemRequest, GetConnectionPasswordRequest, GetConnectionsRequest, GetInsertQueryRequest, GetDefinitionQueryForItemRequest, ProgressNotificationComplete, ProgressNotificationCompleteParams, ProgressNotificationStart, ProgressNotificationStartParams, ReleaseResultsRequest, RunCommandRequest, GetResultsRequest, SearchConnectionItemsRequest, TestConnectionRequest, GetERDiagramDataRequest } from './contracts';
 import DependencyManager from './dependency-manager/extension';
 import { getExtension, resolveConnection } from './extension-util';
 import statusBar from './status-bar';
@@ -32,6 +33,7 @@ export class ConnectionManagerPlugin implements IExtensionPlugin {
   public client: ILanguageClient;
   public resultsWebview: ResultsWebviewManager;
   public settingsWebview: SettingsWebview;
+  public erDiagramWebview: ERDiagramWebview;
   private errorHandler: IExtension['errorHandler'];
   private explorer: ConnectionExplorer;
   private codeLensPlugin: CodeLensPlugin;
@@ -120,6 +122,56 @@ export class ConnectionManagerPlugin implements IExtensionPlugin {
 
   private ext_describeFunction() {
     window.showInformationMessage('Not implemented yet.');
+  }
+
+  private ext_showERDiagram = async (node?: SidebarItem) => {
+    try {
+      const conn = await this.explorer.getActive();
+      if (!conn) {
+        window.showWarningMessage('Please connect to a database first.');
+        return;
+      }
+
+      let schema: NSDatabase.ISchema;
+      if (node && node.metadata && node.metadata.type === ContextValue.SCHEMA) {
+        schema = node.metadata as unknown as NSDatabase.ISchema;
+      } else if (node && node.metadata && node.metadata.schema) {
+        schema = {
+          label: node.metadata.schema,
+          schema: node.metadata.schema,
+          database: node.metadata.database,
+          type: ContextValue.SCHEMA,
+          iconId: 'group-by-ref-type',
+        } as NSDatabase.ISchema;
+      } else {
+        // Try to pick a schema from the connection
+        const loadOptions = (search: string) => this.client.sendRequest(SearchConnectionItemsRequest, { conn, itemType: ContextValue.SCHEMA, search }).then(({ results }) => results);
+        schema = await quickPickSearch<NSDatabase.ISchema>(loadOptions, {
+          matchOnDescription: true,
+          matchOnDetail: true,
+          title: `Select a schema for ER Diagram`,
+          placeHolder: 'Type to search schemas...',
+        });
+      }
+
+      if (!schema) return;
+
+      // Ensure schema has database field from connection if missing
+      if (!schema.database && conn.database) {
+        schema.database = conn.database;
+      }
+
+      const erData = await this.client.sendRequest(GetERDiagramDataRequest, { conn, schema });
+
+      this.erDiagramWebview.show();
+      this.erDiagramWebview.updateDiagram({
+        ...erData,
+        schemaName: schema.label || schema.schema,
+        connectionName: conn.name,
+      });
+    } catch (e) {
+      this.errorHandler('Error generating ER diagram', e);
+    }
   }
 
   private ext_closeConnection = async (node?: SidebarConnection) => {
@@ -808,7 +860,8 @@ export class ConnectionManagerPlugin implements IExtensionPlugin {
       .registerCommand(`copyTextFromTreeItem`, this.ext_copyTextFromTreeItem)
       .registerCommand(`getChildrenForTreeItem`, this.ext_getChildrenForTreeItem)
       .registerCommand(`getDefinitionQueryForItem`, this.ext_getDefinitionQueryForItem)
-      .registerCommand(`getInsertQuery`, this.ext_getInsertQuery);
+      .registerCommand(`getInsertQuery`, this.ext_getInsertQuery)
+      .registerCommand(`showERDiagram`, this.ext_showERDiagram);
 
     this.errorHandler = extension.errorHandler;
     this.explorer = new ConnectionExplorer();
@@ -825,6 +878,7 @@ export class ConnectionManagerPlugin implements IExtensionPlugin {
     Context.subscriptions.push(
       (this.resultsWebview = new ResultsWebviewManager(this.syncConsoleMessages)),
       (this.settingsWebview = new SettingsWebview()),
+      (this.erDiagramWebview = new ERDiagramWebview()),
       statusBar,
       workspace.onDidCloseTextDocument(this.onDidOpenOrCloseTextDocument),
       workspace.onDidOpenTextDocument(this.onDidOpenOrCloseTextDocument),

--- a/packages/plugins/connection-manager/language-server.ts
+++ b/packages/plugins/connection-manager/language-server.ts
@@ -3,7 +3,7 @@ import ConfigRO from '@sqltools/util/config-manager';
 import { IConnection, NSDatabase, ILanguageServerPlugin, ILanguageServer, RequestHandler } from '@sqltools/types';
 import { getConnectionId, migrateConnectionSetting } from '@sqltools/util/connection';
 import csvStringify from 'csv-stringify/lib/sync';
-import { ConnectRequest, DisconnectRequest, SearchConnectionItemsRequest, GetConnectionPasswordRequest, GetConnectionsRequest, RunCommandRequest, GetResultsRequest, ProgressNotificationStart, ProgressNotificationComplete, TestConnectionRequest, GetChildrenForTreeItemRequest, ForceListRefresh, GetInsertQueryRequest, GetDefinitionQueryForItemRequest, ReleaseResultsRequest } from './contracts';
+import { ConnectRequest, DisconnectRequest, SearchConnectionItemsRequest, GetConnectionPasswordRequest, GetConnectionsRequest, RunCommandRequest, GetResultsRequest, ProgressNotificationStart, ProgressNotificationComplete, TestConnectionRequest, GetChildrenForTreeItemRequest, ForceListRefresh, GetInsertQueryRequest, GetDefinitionQueryForItemRequest, ReleaseResultsRequest, GetERDiagramDataRequest } from './contracts';
 import Handlers from './cache/handlers';
 import decorateLSException from '@sqltools/util/decorators/ls-decorate-exception';
 import { createLogger } from '@sqltools/log/src';
@@ -254,6 +254,20 @@ export default class ConnectionManagerPlugin implements ILanguageServerPlugin {
     return c.getInsertQuery(params);
   };
 
+  private GetERDiagramDataHandler: RequestHandler<typeof GetERDiagramDataRequest> = async (req) => {
+    if (!req || !req.conn) {
+      return { tables: [], columns: {}, foreignKeys: [] };
+    }
+    const { conn, schema } = req;
+    const c = await this.getConnectionInstance(conn);
+    if (!c) return { tables: [], columns: {}, foreignKeys: [] };
+    // Ensure schema has database field populated from connection if missing
+    if (!schema.database && conn.database) {
+      schema.database = conn.database;
+    }
+    return c.getERDiagramData(schema);
+  };
+
   public register(server: typeof ConnectionManagerPlugin.prototype['server']) {
     this.server = this.server || server;
 
@@ -269,6 +283,7 @@ export default class ConnectionManagerPlugin implements ILanguageServerPlugin {
     this.server.onRequest(GetChildrenForTreeItemRequest, this.GetChildrenForTreeItemHandler);
     this.server.onRequest(GetDefinitionQueryForItemRequest, this.GetDefinitionQueryForItemHandler);
     this.server.onRequest(GetInsertQueryRequest, this.GetInsertQueryHandler);
+    this.server.onRequest(GetERDiagramDataRequest, this.GetERDiagramDataHandler);
     this.server.addOnDidChangeConfigurationHooks(() => this._autoConnectIfActive());
   }
 

--- a/packages/plugins/connection-manager/webview/er-diagram.ts
+++ b/packages/plugins/connection-manager/webview/er-diagram.ts
@@ -1,0 +1,41 @@
+import WebviewProvider from '@sqltools/vscode/webview-provider';
+import { DISPLAY_NAME } from '@sqltools/util/constants';
+import { NSDatabase } from '@sqltools/types';
+import { ViewColumn } from 'vscode';
+
+export interface ERDiagramData {
+  tables: NSDatabase.ITable[];
+  columns: { [tableName: string]: NSDatabase.IColumn[] };
+  foreignKeys: NSDatabase.IForeignKey[];
+  schemaName: string;
+  connectionName: string;
+}
+
+export const ERDiagramAction = {
+  RESPONSE_ER_DATA: 'RESPONSE:ER_DATA' as const,
+  NOTIFY_VIEW_READY: 'NOTIFY:VIEW_READY' as const,
+};
+
+export default class ERDiagramWebview extends WebviewProvider<ERDiagramData> {
+  protected id: string = 'ERDiagram';
+  protected title: string = `${DISPLAY_NAME} ER Diagram`;
+
+  protected cssVariables = {};
+
+  protected messagesHandler = (_msg: { action: string; payload: any }) => {
+    // Handle messages from the webview if needed
+  };
+
+  public updateDiagram(data: ERDiagramData) {
+    this.title = `ER Diagram: ${data.connectionName} - ${data.schemaName}`;
+    this.updatePanelName();
+    this.sendMessage(ERDiagramAction.RESPONSE_ER_DATA, data);
+  }
+
+  public show() {
+    this.whereToShow = ViewColumn.One;
+    super.show();
+  }
+
+  whereToShow = ViewColumn.One;
+}

--- a/packages/plugins/connection-manager/webview/ui/screens/ERDiagram/actions.ts
+++ b/packages/plugins/connection-manager/webview/ui/screens/ERDiagram/actions.ts
@@ -1,0 +1,6 @@
+import { DefaultUIAction } from '@sqltools/vscode/webview-provider/action';
+
+export const UIAction = {
+  ...DefaultUIAction,
+  RESPONSE_ER_DATA: 'RESPONSE:ER_DATA' as const,
+} as const;

--- a/packages/plugins/connection-manager/webview/ui/screens/ERDiagram/components/ERDiagramContainer.tsx
+++ b/packages/plugins/connection-manager/webview/ui/screens/ERDiagram/components/ERDiagramContainer.tsx
@@ -1,0 +1,581 @@
+import React, { useEffect, useState, useCallback, useRef } from 'react';
+import ReactFlow, {
+  Node,
+  Edge,
+  Position,
+  Handle,
+  Controls,
+  Background,
+  useNodesState,
+  useEdgesState,
+  MarkerType,
+  useReactFlow,
+  ReactFlowProvider,
+  NodeMouseHandler,
+} from 'react-flow-renderer';
+import dagre from 'dagre';
+import 'react-flow-renderer/dist/style.css';
+
+// Hide React Flow attribution watermark
+const hideAttribution = document.createElement('style');
+hideAttribution.textContent = '.react-flow__attribution { display: none !important; }';
+document.head.appendChild(hideAttribution);
+import { UIAction } from '../actions';
+import sendMessage from '../../../lib/messages';
+import Loading from '../../../components/Loading';
+
+// ─── Types ─────────────────────────────────────────────────────────
+
+interface IColumn {
+  label: string;
+  dataType: string;
+  isPk?: boolean;
+  isFk?: boolean;
+  isNullable?: boolean | string;
+}
+
+interface IForeignKey {
+  constraintName: string;
+  sourceTableSchema: string;
+  sourceTableName: string;
+  sourceColumnName: string;
+  targetTableSchema: string;
+  targetTableName: string;
+  targetColumnName: string;
+}
+
+interface ERData {
+  tables: Array<{ label: string }>;
+  columns: { [tableName: string]: IColumn[] };
+  foreignKeys: IForeignKey[];
+  schemaName: string;
+  connectionName: string;
+}
+
+// ─── Focus helpers ─────────────────────────────────────────────────
+
+function getConnectedTableIds(tableId: string, foreignKeys: IForeignKey[]): Set<string> {
+  const connected = new Set<string>();
+  connected.add(tableId);
+  for (const fk of foreignKeys) {
+    if (fk.sourceTableName === tableId) connected.add(fk.targetTableName);
+    if (fk.targetTableName === tableId) connected.add(fk.sourceTableName);
+  }
+  return connected;
+}
+
+function getConnectedEdgeIds(tableId: string, edges: Edge[]): Set<string> {
+  const ids = new Set<string>();
+  for (const e of edges) {
+    if (e.source === tableId || e.target === tableId) ids.add(e.id);
+  }
+  return ids;
+}
+
+const DIM_OPACITY = 0.15;
+
+// ─── Table color palette ───────────────────────────────────────────
+
+const TABLE_COLORS = [
+  '#3794ff', // blue
+  '#89d185', // green
+  '#cca700', // yellow
+  '#e06c75', // red
+  '#c678dd', // purple
+  '#56b6c2', // cyan
+  '#d19a66', // orange
+  '#61afef', // light blue
+  '#98c379', // lime
+  '#e5c07b', // gold
+  '#be5046', // rust
+  '#c882e7', // lavender
+];
+
+function hashString(s: string): number {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) {
+    h = ((h << 5) - h + s.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h);
+}
+
+function getTableColor(name: string): string {
+  return TABLE_COLORS[hashString(name) % TABLE_COLORS.length];
+}
+
+// ─── Custom Table Node ─────────────────────────────────────────────
+
+const ROW_HEIGHT = 28;
+const HEADER_HEIGHT = 36;
+
+interface TableNodeData {
+  label: string;
+  columns: IColumn[];
+  dimmed?: boolean;
+  focused?: boolean;
+  color: string;
+}
+
+function TableNodeComponent({ data }: { data: TableNodeData }) {
+  const { label, columns, dimmed, focused, color } = data;
+  const width = Math.max(220, label.length * 9 + 40, ...columns.map(c => (c.label.length + (c.dataType || '').length) * 7.5 + 80));
+
+  return (
+    <div style={{
+      background: 'var(--vscode-editor-background, #1e1e1e)',
+      border: focused
+        ? `2px solid ${color}`
+        : '1.5px solid var(--vscode-panel-border, #555)',
+      borderRadius: 6,
+      overflow: 'hidden',
+      minWidth: width,
+      fontSize: 12,
+      fontFamily: 'var(--vscode-font-family, sans-serif)',
+      boxShadow: focused
+        ? `0 0 12px ${color}66, 0 2px 8px rgba(0,0,0,0.3)`
+        : '0 2px 8px rgba(0,0,0,0.3)',
+      opacity: dimmed ? DIM_OPACITY : 1,
+      transition: 'opacity 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease',
+    }}>
+      {/* Header with table color accent */}
+      <div style={{
+        background: 'var(--vscode-sideBarSectionHeader-background, #37373d)',
+        padding: '8px 12px',
+        fontWeight: 'bold',
+        fontSize: 13,
+        color: 'var(--vscode-sideBarSectionHeader-foreground, #ccc)',
+        borderBottom: '1px solid var(--vscode-panel-border, #555)',
+        textAlign: 'center',
+        borderTop: `3px solid ${color}`,
+      }}>
+        {label}
+      </div>
+
+      {/* Columns */}
+      {columns.length === 0 && (
+        <div style={{ padding: '8px 12px', color: 'var(--vscode-descriptionForeground, #666)', fontStyle: 'italic' }}>
+          no columns
+        </div>
+      )}
+      {columns.map((col, i) => (
+        <div key={col.label + i} style={{
+          position: 'relative',
+          display: 'flex',
+          alignItems: 'center',
+          padding: '4px 12px',
+          height: ROW_HEIGHT,
+          background: i % 2 === 1 ? 'var(--vscode-list-hoverBackground, rgba(255,255,255,0.04))' : 'transparent',
+          borderBottom: i < columns.length - 1 ? '1px solid var(--vscode-widget-border, rgba(255,255,255,0.06))' : 'none',
+        }}>
+          <Handle type="target" position={Position.Left} id={`${col.label}-target`}
+            style={{ top: '50%', width: 1, height: 1, background: 'transparent', border: 'none', opacity: 0 }}
+          />
+          <Handle type="source" position={Position.Right} id={`${col.label}-source`}
+            style={{ top: '50%', width: 1, height: 1, background: 'transparent', border: 'none', opacity: 0 }}
+          />
+          <span style={{
+            width: 22, fontSize: 9, fontWeight: 'bold', flexShrink: 0,
+            color: col.isPk ? 'var(--vscode-charts-yellow, #cca700)' : col.isFk ? 'var(--vscode-charts-blue, #3794ff)' : 'transparent',
+          }}>
+            {col.isPk ? 'PK' : col.isFk ? 'FK' : ''}
+          </span>
+          <span style={{
+            flex: 1, color: 'var(--vscode-editor-foreground, #d4d4d4)',
+            fontFamily: 'var(--vscode-editor-fontFamily, Consolas, monospace)',
+            overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+          }}>
+            {col.label}
+          </span>
+          <span style={{
+            color: 'var(--vscode-descriptionForeground, #888)',
+            fontFamily: 'var(--vscode-editor-fontFamily, Consolas, monospace)',
+            fontSize: 11, marginLeft: 8, flexShrink: 0,
+          }}>
+            {(col.dataType || '').toUpperCase()}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+const nodeTypes = { tableNode: TableNodeComponent };
+
+// ─── Layout with dagre ─────────────────────────────────────────────
+
+function measureNode(label: string, cols: IColumn[]): { w: number; h: number } {
+  const w = Math.max(220, label.length * 9 + 40, ...cols.map(c => (c.label.length + (c.dataType || '').length) * 7.5 + 80));
+  const h = HEADER_HEIGHT + Math.max(cols.length, 1) * ROW_HEIGHT + 8;
+  return { w, h };
+}
+
+function buildNodesAndEdges(data: ERData): { nodes: Node[]; edges: Edge[] } {
+  const { tables, columns, foreignKeys } = data;
+
+  // Build edges with color from source table
+  const edges: Edge[] = foreignKeys.map((fk, i) => {
+    const color = getTableColor(fk.sourceTableName);
+    return {
+      id: `fk-${i}`,
+      source: fk.sourceTableName,
+      sourceHandle: `${fk.sourceColumnName}-source`,
+      target: fk.targetTableName,
+      targetHandle: `${fk.targetColumnName}-target`,
+      type: 'default',
+      animated: false,
+      style: { stroke: color, strokeWidth: 2 },
+      label: fk.sourceColumnName,
+      labelStyle: { fill: 'var(--vscode-descriptionForeground, #888)', fontSize: 10, fontFamily: 'var(--vscode-font-family, sans-serif)' },
+      labelBgStyle: { fill: 'var(--vscode-editor-background, #1e1e1e)', fillOpacity: 0.85 },
+      labelBgPadding: [4, 2] as [number, number],
+      labelBgBorderRadius: 3,
+    };
+  });
+
+  // Use dagre for layout
+  const g = new dagre.graphlib.Graph();
+  g.setDefaultEdgeLabel(() => ({}));
+  g.setGraph({
+    rankdir: 'LR',    // left-to-right flow
+    nodesep: 60,       // vertical spacing between nodes in same rank
+    ranksep: 120,      // horizontal spacing between ranks
+    edgesep: 30,       // spacing between edges
+    marginx: 40,
+    marginy: 40,
+  });
+
+  // Add nodes with measured dimensions
+  for (const t of tables) {
+    const cols = columns[t.label] || [];
+    const { w, h } = measureNode(t.label, cols);
+    g.setNode(t.label, { width: w, height: h });
+  }
+
+  // Add edges
+  for (const fk of foreignKeys) {
+    if (g.hasNode(fk.sourceTableName) && g.hasNode(fk.targetTableName)) {
+      g.setEdge(fk.sourceTableName, fk.targetTableName);
+    }
+  }
+
+  dagre.layout(g);
+
+  // Build React Flow nodes from dagre positions
+  const nodes: Node[] = tables.map(t => {
+    const cols = columns[t.label] || [];
+    const { w, h } = measureNode(t.label, cols);
+    const pos = g.node(t.label);
+    return {
+      id: t.label,
+      type: 'tableNode',
+      // dagre gives center position, React Flow uses top-left
+      position: { x: pos.x - w / 2, y: pos.y - h / 2 },
+      data: { label: t.label, columns: cols, dimmed: false, focused: false, color: getTableColor(t.label) },
+    };
+  });
+
+  return { nodes, edges };
+}
+
+// ─── Inner Flow (needs ReactFlowProvider) ──────────────────────────
+
+function ERFlowInner({ data, focusedTable, setFocusedTable }: {
+  data: ERData;
+  focusedTable: string | null;
+  setFocusedTable: (t: string | null) => void;
+}) {
+  const [nodes, setNodes, onNodesChange] = useNodesState([]);
+  const [edges, setEdges, onEdgesChange] = useEdgesState([]);
+  const [baseNodes, setBaseNodes] = useState<Node[]>([]);
+  const [baseEdges, setBaseEdges] = useState<Edge[]>([]);
+  const reactFlow = useReactFlow();
+
+  // Build initial layout
+  useEffect(() => {
+    const { nodes: n, edges: e } = buildNodesAndEdges(data);
+    setBaseNodes(n);
+    setBaseEdges(e);
+    setNodes(n);
+    setEdges(e);
+  }, [data]);
+
+  // Apply focus mode
+  useEffect(() => {
+    if (!focusedTable) {
+      setNodes(baseNodes.map(n => ({
+        ...n,
+        data: { ...n.data, dimmed: false, focused: false },
+      })));
+      setEdges(baseEdges.map(e => ({
+        ...e,
+        style: { ...e.style, opacity: 1 },
+        animated: false,
+      })));
+      return;
+    }
+
+    const connectedNodes = getConnectedTableIds(focusedTable, data.foreignKeys);
+    const connectedEdges = getConnectedEdgeIds(focusedTable, baseEdges);
+
+    setNodes(baseNodes.map(n => ({
+      ...n,
+      data: {
+        ...n.data,
+        dimmed: !connectedNodes.has(n.id),
+        focused: n.id === focusedTable,
+      },
+    })));
+
+    setEdges(baseEdges.map(e => ({
+      ...e,
+      style: {
+        ...e.style,
+        opacity: connectedEdges.has(e.id) ? 1 : DIM_OPACITY,
+        strokeWidth: connectedEdges.has(e.id) ? 3 : 2,
+      },
+      animated: connectedEdges.has(e.id),
+    })));
+  }, [focusedTable, baseNodes, baseEdges, data]);
+
+  // Pan to focused table
+  useEffect(() => {
+    if (!focusedTable || baseNodes.length === 0) return;
+    const node = baseNodes.find(n => n.id === focusedTable);
+    if (!node) return;
+    const cols = data.columns[focusedTable] || [];
+    const { w, h } = measureNode(focusedTable, cols);
+    reactFlow.setCenter(node.position.x + w / 2, node.position.y + h / 2, { zoom: 0.75, duration: 800 });
+  }, [focusedTable, baseNodes]);
+
+  const onNodeClick: NodeMouseHandler = useCallback((_event, node) => {
+    setFocusedTable(focusedTable === node.id ? null : node.id);
+  }, [focusedTable, setFocusedTable]);
+
+  const onPaneClick = useCallback(() => {
+    setFocusedTable(null);
+  }, [setFocusedTable]);
+
+  return (
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      onNodesChange={onNodesChange}
+      onEdgesChange={onEdgesChange}
+      onNodeClick={onNodeClick}
+      onPaneClick={onPaneClick}
+      nodeTypes={nodeTypes}
+      fitView
+      fitViewOptions={{ padding: 0.2 }}
+      minZoom={0.05}
+      maxZoom={3}
+      defaultEdgeOptions={{ type: 'default' }}
+      style={{ background: 'var(--vscode-editor-background, #1e1e1e)' }}
+    >
+      <Background color="var(--vscode-widget-border, rgba(255,255,255,0.05))" gap={20} />
+      <Controls
+        style={{
+          background: 'var(--vscode-sideBar-background, #252526)',
+          border: '1px solid var(--vscode-panel-border, #555)',
+          borderRadius: 4,
+        }}
+      />
+    </ReactFlow>
+  );
+}
+
+// ─── Table Search Component ────────────────────────────────────────
+
+function TableSearch({ tables, focusedTable, onSelect }: {
+  tables: Array<{ label: string }>;
+  focusedTable: string | null;
+  onSelect: (name: string | null) => void;
+}) {
+  const [search, setSearch] = useState('');
+  const [open, setOpen] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const filtered = search
+    ? tables.filter(t => t.label.toLowerCase().includes(search.toLowerCase()))
+    : tables;
+
+  const handleSelect = (name: string) => {
+    onSelect(focusedTable === name ? null : name);
+    setSearch('');
+    setOpen(false);
+    inputRef.current?.blur();
+  };
+
+  const handleClear = () => {
+    onSelect(null);
+    setSearch('');
+    setOpen(false);
+  };
+
+  return (
+    <div style={{ position: 'relative' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+        <input
+          ref={inputRef}
+          type="text"
+          placeholder={focusedTable ? focusedTable : 'Search tables...'}
+          value={search}
+          onChange={e => { setSearch(e.target.value); setOpen(true); }}
+          onFocus={() => setOpen(true)}
+          onKeyDown={e => {
+            if (e.key === 'Escape') { setOpen(false); setSearch(''); onSelect(null); inputRef.current?.blur(); }
+            if (e.key === 'Enter' && filtered.length > 0) handleSelect(filtered[0].label);
+          }}
+          style={{
+            background: 'var(--vscode-input-background, #3c3c3c)',
+            color: 'var(--vscode-input-foreground, #ccc)',
+            border: '1px solid var(--vscode-input-border, #555)',
+            borderRadius: 3,
+            padding: '3px 8px',
+            fontSize: 12,
+            width: 180,
+            outline: 'none',
+            fontFamily: 'var(--vscode-font-family, sans-serif)',
+          }}
+        />
+        {focusedTable && (
+          <button onClick={handleClear} style={{
+            ...btnStyle,
+            padding: '3px 6px',
+            fontSize: 10,
+          }}>✕</button>
+        )}
+      </div>
+      {open && filtered.length > 0 && (
+        <div style={{
+          position: 'absolute',
+          top: '100%',
+          left: 0,
+          marginTop: 2,
+          background: 'var(--vscode-dropdown-background, #3c3c3c)',
+          border: '1px solid var(--vscode-dropdown-border, #555)',
+          borderRadius: 4,
+          maxHeight: 240,
+          overflowY: 'auto',
+          zIndex: 100,
+          width: 220,
+          boxShadow: '0 4px 12px rgba(0,0,0,0.4)',
+        }}>
+          {filtered.map(t => (
+            <div
+              key={t.label}
+              onClick={() => handleSelect(t.label)}
+              style={{
+                padding: '5px 10px',
+                cursor: 'pointer',
+                fontSize: 12,
+                color: focusedTable === t.label ? 'var(--vscode-list-activeSelectionForeground, #fff)' : 'var(--vscode-dropdown-foreground, #ccc)',
+                background: focusedTable === t.label ? 'var(--vscode-list-activeSelectionBackground, #094771)' : 'transparent',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 6,
+              }}
+              onMouseEnter={e => {
+                if (focusedTable !== t.label) (e.currentTarget as HTMLDivElement).style.background = 'var(--vscode-list-hoverBackground, rgba(255,255,255,0.08))';
+              }}
+              onMouseLeave={e => {
+                if (focusedTable !== t.label) (e.currentTarget as HTMLDivElement).style.background = 'transparent';
+              }}
+            >
+              <span style={{ width: 8, height: 8, borderRadius: '50%', background: getTableColor(t.label), flexShrink: 0 }} />
+              {t.label}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Main Component ────────────────────────────────────────────────
+
+export default function ERDiagramContainer() {
+  const [data, setData] = useState<ERData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [focusedTable, setFocusedTable] = useState<string | null>(null);
+
+  useEffect(() => {
+    const handler = (event: MessageEvent) => {
+      const { action, payload } = event.data;
+      if (action === UIAction.RESPONSE_ER_DATA) {
+        setData(payload);
+        setLoading(false);
+      }
+    };
+    window.addEventListener('message', handler);
+    sendMessage(UIAction.NOTIFY_VIEW_READY, true);
+    return () => window.removeEventListener('message', handler);
+  }, []);
+
+  // Escape key to clear focus
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setFocusedTable(null);
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+
+  if (loading) return <div style={centerStyle}><Loading /></div>;
+
+  if (!data || data.tables.length === 0) {
+    return (
+      <div style={centerStyle}>
+        <p>No tables found in schema <strong>{data?.schemaName || 'unknown'}</strong>.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ width: '100%', height: '100vh', background: 'var(--vscode-editor-background, #1e1e1e)' }}>
+      <div style={toolbarStyle}>
+        <span>
+          <strong style={{ color: 'var(--vscode-foreground)' }}>{data.connectionName}</strong>
+          {' / '}
+          <strong style={{ color: 'var(--vscode-foreground)' }}>{data.schemaName}</strong>
+        </span>
+        <span>{data.tables.length} tables</span>
+        <span>{data.foreignKeys.length} relationships</span>
+        <TableSearch
+          tables={data.tables}
+          focusedTable={focusedTable}
+          onSelect={setFocusedTable}
+        />
+        <span style={{ marginLeft: 'auto', fontSize: 11, color: 'var(--vscode-descriptionForeground)' }}>
+          Click a table to focus · Esc to clear
+        </span>
+      </div>
+      <div style={{ width: '100%', height: 'calc(100vh - 36px)' }}>
+        <ReactFlowProvider>
+          <ERFlowInner data={data} focusedTable={focusedTable} setFocusedTable={setFocusedTable} />
+        </ReactFlowProvider>
+      </div>
+    </div>
+  );
+}
+
+const centerStyle: React.CSSProperties = {
+  display: 'flex', alignItems: 'center', justifyContent: 'center',
+  height: '100vh', color: 'var(--vscode-foreground)',
+};
+
+const toolbarStyle: React.CSSProperties = {
+  padding: '6px 16px',
+  borderBottom: '1px solid var(--vscode-panel-border, #444)',
+  display: 'flex', alignItems: 'center', gap: '12px',
+  fontSize: '12px', color: 'var(--vscode-descriptionForeground)',
+  userSelect: 'none',
+  background: 'var(--vscode-sideBar-background, #252526)',
+};
+
+const btnStyle: React.CSSProperties = {
+  background: 'var(--vscode-button-secondaryBackground, #3a3d41)',
+  color: 'var(--vscode-button-secondaryForeground, #ccc)',
+  border: '1px solid var(--vscode-panel-border, #555)',
+  borderRadius: 3, cursor: 'pointer',
+  fontSize: '11px', lineHeight: '16px',
+};

--- a/packages/plugins/connection-manager/webview/ui/screens/ERDiagram/components/ERDiagramContainer.tsx
+++ b/packages/plugins/connection-manager/webview/ui/screens/ERDiagram/components/ERDiagramContainer.tsx
@@ -8,7 +8,6 @@ import ReactFlow, {
   Background,
   useNodesState,
   useEdgesState,
-  MarkerType,
   useReactFlow,
   ReactFlowProvider,
   NodeMouseHandler,

--- a/packages/plugins/connection-manager/webview/ui/screens/ERDiagram/index.tsx
+++ b/packages/plugins/connection-manager/webview/ui/screens/ERDiagram/index.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render } from 'react-dom';
+import Themed from '../../components/Themed';
+import ERDiagramContainer from './components/ERDiagramContainer';
+
+render(
+  <Themed>
+    <ERDiagramContainer />
+  </Themed>,
+  document.getElementById('app-root')
+);

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -55,6 +55,7 @@ export interface IBaseQueries {
   describeTable: QueryBuilder<NSDatabase.ITable, any>;
   fetchColumns: QueryBuilder<NSDatabase.ITable, NSDatabase.IColumn>;
   fetchFunctions?: QueryBuilder<NSDatabase.ISchema, NSDatabase.IFunction>;
+  fetchForeignKeys?: QueryBuilder<NSDatabase.ISchema, NSDatabase.IForeignKey>;
   [id: string]: string | ((params: any) => (string | IExpectedResult));
 }
 
@@ -331,6 +332,7 @@ export interface IConnectionDriver {
    * Get an INSERT query for item
    */
   getInsertQuery?(params: { item: NSDatabase.ITable, columns: Array<NSDatabase.IColumn> }): Promise<string>;
+  getERDiagramData?(schema: NSDatabase.ISchema): Promise<{ tables: NSDatabase.ITable[], columns: { [tableName: string]: NSDatabase.IColumn[] }, foreignKeys: NSDatabase.IForeignKey[] }>;
   /**
    * Create an SSH tunnel
    */
@@ -504,6 +506,16 @@ export namespace NSDatabase {
     queryType?: 'showRecords' | 'describeTable';
     queryParams?: { [k: string]: any };
   }
+  export interface IForeignKey {
+    constraintName: string;
+    sourceTableSchema: string;
+    sourceTableName: string;
+    sourceColumnName: string;
+    targetTableSchema: string;
+    targetTableName: string;
+    targetColumnName: string;
+  }
+
   export type SearchableItem = IDatabase | ISchema | ITable | IColumn | IFunction | IProcedure | MConnectionExplorer.IChildItem;
   export type ParentItem = IDatabase | ISchema | ITable;
   export type DefinableItem = ITable | IFunction | IProcedure | IIndex | ITrigger;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2856,10 +2856,10 @@
   resolved "https://registry.yarnpkg.com/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz#185c1a80cc807fdda2a3fe960f7c11c4a27952e1"
   integrity sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==
 
-"@types/d3-dispatch@*":
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz#ef004d8a128046cfce434d17182f834e44ef95b2"
-  integrity sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==
+"@types/d3-dispatch@*", "@types/d3-dispatch@3.0.5":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@types/d3-dispatch/-/d3-dispatch-3.0.5.tgz#918f37deaf74485371fa0ab21365ecb415258d89"
+  integrity sha512-hxvq2kc+9hydVppo21JCGfcM0tLTh1DXnG3MLN0KlxsNZJH4bsdl1iXDuWtXFpWWlBrCMwSqlnoLPDxNAZU3Bg==
 
 "@types/d3-drag@*":
   version "3.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1581,6 +1581,11 @@
     core-js "^2.6.12"
     regenerator-runtime "^0.14.0"
 
+"@babel/runtime@^7.18.9":
+  version "7.29.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.2.tgz#9a6e2d05f4b6692e1801cd4fb176ad823930ed5e"
+  integrity sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==
+
 "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
   version "7.26.10"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.10.tgz#a07b4d8fa27af131a633d7b3524db803eb4764c2"
@@ -2809,6 +2814,226 @@
   resolved "https://registry.npmjs.org/@types/command-exists/-/command-exists-1.2.0.tgz"
   integrity sha512-ugsxEJfsCuqMLSuCD4PIJkp5Uk2z6TCMRCgYVuhRo5cYQY3+1xXTQkSlPtkpGHuvWMjS2KTeVQXxkXRACMbM6A==
 
+"@types/d3-array@*":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@types/d3-array/-/d3-array-3.2.2.tgz#e02151464d02d4a1b44646d0fcdb93faf88fde8c"
+  integrity sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==
+
+"@types/d3-axis@*":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/d3-axis/-/d3-axis-3.0.6.tgz#e760e5765b8188b1defa32bc8bb6062f81e4c795"
+  integrity sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==
+  dependencies:
+    "@types/d3-selection" "*"
+
+"@types/d3-brush@*":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/d3-brush/-/d3-brush-3.0.6.tgz#c2f4362b045d472e1b186cdbec329ba52bdaee6c"
+  integrity sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==
+  dependencies:
+    "@types/d3-selection" "*"
+
+"@types/d3-chord@*":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/d3-chord/-/d3-chord-3.0.6.tgz#1706ca40cf7ea59a0add8f4456efff8f8775793d"
+  integrity sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==
+
+"@types/d3-color@*":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@types/d3-color/-/d3-color-3.1.3.tgz#368c961a18de721da8200e80bf3943fb53136af2"
+  integrity sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==
+
+"@types/d3-contour@*":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/d3-contour/-/d3-contour-3.0.6.tgz#9ada3fa9c4d00e3a5093fed0356c7ab929604231"
+  integrity sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==
+  dependencies:
+    "@types/d3-array" "*"
+    "@types/geojson" "*"
+
+"@types/d3-delaunay@*":
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz#185c1a80cc807fdda2a3fe960f7c11c4a27952e1"
+  integrity sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==
+
+"@types/d3-dispatch@*":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz#ef004d8a128046cfce434d17182f834e44ef95b2"
+  integrity sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==
+
+"@types/d3-drag@*":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@types/d3-drag/-/d3-drag-3.0.7.tgz#b13aba8b2442b4068c9a9e6d1d82f8bcea77fc02"
+  integrity sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==
+  dependencies:
+    "@types/d3-selection" "*"
+
+"@types/d3-dsv@*":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@types/d3-dsv/-/d3-dsv-3.0.7.tgz#0a351f996dc99b37f4fa58b492c2d1c04e3dac17"
+  integrity sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==
+
+"@types/d3-ease@*":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/d3-ease/-/d3-ease-3.0.2.tgz#e28db1bfbfa617076f7770dd1d9a48eaa3b6c51b"
+  integrity sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==
+
+"@types/d3-fetch@*":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@types/d3-fetch/-/d3-fetch-3.0.7.tgz#c04a2b4f23181aa376f30af0283dbc7b3b569980"
+  integrity sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==
+  dependencies:
+    "@types/d3-dsv" "*"
+
+"@types/d3-force@*":
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/@types/d3-force/-/d3-force-3.0.10.tgz#6dc8fc6e1f35704f3b057090beeeb7ac674bff1a"
+  integrity sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==
+
+"@types/d3-format@*":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/d3-format/-/d3-format-3.0.4.tgz#b1e4465644ddb3fdf3a263febb240a6cd616de90"
+  integrity sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==
+
+"@types/d3-geo@*":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-geo/-/d3-geo-3.1.0.tgz#b9e56a079449174f0a2c8684a9a4df3f60522440"
+  integrity sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==
+  dependencies:
+    "@types/geojson" "*"
+
+"@types/d3-hierarchy@*":
+  version "3.1.7"
+  resolved "https://registry.yarnpkg.com/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz#6023fb3b2d463229f2d680f9ac4b47466f71f17b"
+  integrity sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==
+
+"@types/d3-interpolate@*":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz#412b90e84870285f2ff8a846c6eb60344f12a41c"
+  integrity sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==
+  dependencies:
+    "@types/d3-color" "*"
+
+"@types/d3-path@*":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-path/-/d3-path-3.1.1.tgz#f632b380c3aca1dba8e34aa049bcd6a4af23df8a"
+  integrity sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==
+
+"@types/d3-polygon@*":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/d3-polygon/-/d3-polygon-3.0.2.tgz#dfae54a6d35d19e76ac9565bcb32a8e54693189c"
+  integrity sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==
+
+"@types/d3-quadtree@*":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz#d4740b0fe35b1c58b66e1488f4e7ed02952f570f"
+  integrity sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==
+
+"@types/d3-random@*":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/d3-random/-/d3-random-3.0.3.tgz#ed995c71ecb15e0cd31e22d9d5d23942e3300cfb"
+  integrity sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==
+
+"@types/d3-scale-chromatic@*":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz#dc6d4f9a98376f18ea50bad6c39537f1b5463c39"
+  integrity sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==
+
+"@types/d3-scale@*":
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/@types/d3-scale/-/d3-scale-4.0.9.tgz#57a2f707242e6fe1de81ad7bfcccaaf606179afb"
+  integrity sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==
+  dependencies:
+    "@types/d3-time" "*"
+
+"@types/d3-selection@*":
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/@types/d3-selection/-/d3-selection-3.0.11.tgz#bd7a45fc0a8c3167a631675e61bc2ca2b058d4a3"
+  integrity sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==
+
+"@types/d3-shape@*":
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/@types/d3-shape/-/d3-shape-3.1.8.tgz#d1516cc508753be06852cd06758e3bb54a22b0e3"
+  integrity sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==
+  dependencies:
+    "@types/d3-path" "*"
+
+"@types/d3-time-format@*":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@types/d3-time-format/-/d3-time-format-4.0.3.tgz#d6bc1e6b6a7db69cccfbbdd4c34b70632d9e9db2"
+  integrity sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==
+
+"@types/d3-time@*":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/d3-time/-/d3-time-3.0.4.tgz#8472feecd639691450dd8000eb33edd444e1323f"
+  integrity sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==
+
+"@types/d3-timer@*":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/d3-timer/-/d3-timer-3.0.2.tgz#70bbda77dc23aa727413e22e214afa3f0e852f70"
+  integrity sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==
+
+"@types/d3-transition@*":
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/@types/d3-transition/-/d3-transition-3.0.9.tgz#1136bc57e9ddb3c390dccc9b5ff3b7d2b8d94706"
+  integrity sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==
+  dependencies:
+    "@types/d3-selection" "*"
+
+"@types/d3-zoom@*":
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/@types/d3-zoom/-/d3-zoom-3.0.8.tgz#dccb32d1c56b1e1c6e0f1180d994896f038bc40b"
+  integrity sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==
+  dependencies:
+    "@types/d3-interpolate" "*"
+    "@types/d3-selection" "*"
+
+"@types/d3@^7.4.0":
+  version "7.4.3"
+  resolved "https://registry.yarnpkg.com/@types/d3/-/d3-7.4.3.tgz#d4550a85d08f4978faf0a4c36b848c61eaac07e2"
+  integrity sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==
+  dependencies:
+    "@types/d3-array" "*"
+    "@types/d3-axis" "*"
+    "@types/d3-brush" "*"
+    "@types/d3-chord" "*"
+    "@types/d3-color" "*"
+    "@types/d3-contour" "*"
+    "@types/d3-delaunay" "*"
+    "@types/d3-dispatch" "*"
+    "@types/d3-drag" "*"
+    "@types/d3-dsv" "*"
+    "@types/d3-ease" "*"
+    "@types/d3-fetch" "*"
+    "@types/d3-force" "*"
+    "@types/d3-format" "*"
+    "@types/d3-geo" "*"
+    "@types/d3-hierarchy" "*"
+    "@types/d3-interpolate" "*"
+    "@types/d3-path" "*"
+    "@types/d3-polygon" "*"
+    "@types/d3-quadtree" "*"
+    "@types/d3-random" "*"
+    "@types/d3-scale" "*"
+    "@types/d3-scale-chromatic" "*"
+    "@types/d3-selection" "*"
+    "@types/d3-shape" "*"
+    "@types/d3-time" "*"
+    "@types/d3-time-format" "*"
+    "@types/d3-timer" "*"
+    "@types/d3-transition" "*"
+    "@types/d3-zoom" "*"
+
+"@types/dagre@^0.7.52":
+  version "0.7.54"
+  resolved "https://registry.yarnpkg.com/@types/dagre/-/dagre-0.7.54.tgz#4f3be2a3f89938b0483013739362a477ec978a84"
+  integrity sha512-QjcRY+adGbYvBFS7cwv5txhVIwX1XXIUswWl+kSQTbI6NjgZydrZkEKX/etzVd7i+bCsCb40Z/xlBY5eoFuvWQ==
+
+"@types/geojson@*":
+  version "7946.0.16"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.16.tgz#8ebe53d69efada7044454e3305c19017d97ced2a"
+  integrity sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==
+
 "@types/glob@*":
   version "7.1.3"
   resolved "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz"
@@ -2968,6 +3193,11 @@
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
+
+"@types/resize-observer-browser@^0.1.7":
+  version "0.1.11"
+  resolved "https://registry.yarnpkg.com/@types/resize-observer-browser/-/resize-observer-browser-0.1.11.tgz#d3c98d788489d8376b7beac23863b1eebdd3c13c"
+  integrity sha512-cNw5iH8JkMkb3QkCoe7DaZiawbDQEUX8t7iuQaRTyLOyQCR2h+ibBD4GJt7p5yhUHrlOeL7ZtbxNHeipqNsBzQ==
 
 "@types/resolve@^1.17.1":
   version "1.17.1"
@@ -3849,6 +4079,11 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+classcat@^5.0.3:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/classcat/-/classcat-5.0.5.tgz#8c209f359a93ac302404a10161b501eba9c09c77"
+  integrity sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==
+
 clean-stack@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
@@ -4216,6 +4451,11 @@ d3-color@1:
   resolved "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz"
   integrity sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==
 
+"d3-color@1 - 3":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
+  integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==
+
 d3-contour@1:
   version "1.3.2"
   resolved "https://registry.npmjs.org/d3-contour/-/d3-contour-1.3.2.tgz"
@@ -4228,6 +4468,11 @@ d3-dispatch@1:
   resolved "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.6.tgz"
   integrity sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==
 
+"d3-dispatch@1 - 3":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-3.0.1.tgz#5fc75284e9c2375c36c839411a0cf550cbfc4d5e"
+  integrity sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==
+
 d3-drag@1:
   version "1.2.5"
   resolved "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.5.tgz"
@@ -4235,6 +4480,14 @@ d3-drag@1:
   dependencies:
     d3-dispatch "1"
     d3-selection "1"
+
+"d3-drag@2 - 3", d3-drag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-drag/-/d3-drag-3.0.0.tgz#994aae9cd23c719f53b5e10e3a0a6108c69607ba"
+  integrity sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-selection "3"
 
 d3-dsv@1:
   version "1.2.0"
@@ -4249,6 +4502,11 @@ d3-ease@1:
   version "1.0.7"
   resolved "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.7.tgz"
   integrity sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ==
+
+"d3-ease@1 - 3":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-3.0.1.tgz#9658ac38a2140d59d346160f1f6c30fda0bd12f4"
+  integrity sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==
 
 d3-fetch@1:
   version "1.2.0"
@@ -4290,6 +4548,13 @@ d3-interpolate@1:
   integrity sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==
   dependencies:
     d3-color "1"
+
+"d3-interpolate@1 - 3":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-3.0.1.tgz#3c47aa5b32c5b3dfb56ef3fd4342078a632b400d"
+  integrity sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==
+  dependencies:
+    d3-color "1 - 3"
 
 d3-path@1:
   version "1.0.9"
@@ -4336,6 +4601,11 @@ d3-selection@1, d3-selection@^1.1.0:
   resolved "https://registry.npmjs.org/d3-selection/-/d3-selection-1.4.2.tgz"
   integrity sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg==
 
+"d3-selection@2 - 3", d3-selection@3, d3-selection@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-3.0.0.tgz#c25338207efa72cc5b9bd1458a1a41901f1e1b31"
+  integrity sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==
+
 d3-shape@1:
   version "1.3.7"
   resolved "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz"
@@ -4360,6 +4630,11 @@ d3-timer@1:
   resolved "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz"
   integrity sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==
 
+"d3-timer@1 - 3":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-3.0.1.tgz#6284d2a2708285b1abb7e201eda4380af35e63b0"
+  integrity sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==
+
 d3-transition@1:
   version "1.3.2"
   resolved "https://registry.npmjs.org/d3-transition/-/d3-transition-1.3.2.tgz"
@@ -4371,6 +4646,17 @@ d3-transition@1:
     d3-interpolate "1"
     d3-selection "^1.1.0"
     d3-timer "1"
+
+"d3-transition@2 - 3":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-transition/-/d3-transition-3.0.1.tgz#6869fdde1448868077fdd5989200cb61b2a1645f"
+  integrity sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==
+  dependencies:
+    d3-color "1 - 3"
+    d3-dispatch "1 - 3"
+    d3-ease "1 - 3"
+    d3-interpolate "1 - 3"
+    d3-timer "1 - 3"
 
 d3-voronoi@1:
   version "1.1.4"
@@ -4387,6 +4673,17 @@ d3-zoom@1:
     d3-interpolate "1"
     d3-selection "1"
     d3-transition "1"
+
+d3-zoom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-zoom/-/d3-zoom-3.0.0.tgz#d13f4165c73217ffeaa54295cd6969b3e7aee8f3"
+  integrity sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-drag "2 - 3"
+    d3-interpolate "1 - 3"
+    d3-selection "2 - 3"
+    d3-transition "2 - 3"
 
 d3@5.7.0:
   version "5.7.0"
@@ -4429,6 +4726,14 @@ d3v3@1.0.3:
   version "1.0.3"
   resolved "https://registry.npmjs.org/d3v3/-/d3v3-1.0.3.tgz"
   integrity sha1-37Ddsh7cPkXD62CzheZYfTFdClk=
+
+dagre@^0.8.5:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/dagre/-/dagre-0.8.5.tgz#ba30b0055dac12b6c1fcc247817442777d06afee"
+  integrity sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==
+  dependencies:
+    graphlib "^2.1.8"
+    lodash "^4.17.15"
 
 dashdash@^1.12.0:
   version "1.14.1"
@@ -5360,6 +5665,13 @@ graceful-fs@^4.2.6:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
+
+graphlib@^2.1.8:
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/graphlib/-/graphlib-2.1.8.tgz#5761d414737870084c92ec7b5dbcb0592c9d35da"
+  integrity sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==
+  dependencies:
+    lodash "^4.17.15"
 
 growly@^1.3.0:
   version "1.3.0"
@@ -8064,6 +8376,20 @@ react-dom@^16.13.1:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
+react-flow-renderer@^10.3.17:
+  version "10.3.17"
+  resolved "https://registry.yarnpkg.com/react-flow-renderer/-/react-flow-renderer-10.3.17.tgz#06d6ecef5559ba5d3e64d2c8dcb74c43071d62b1"
+  integrity sha512-bywiqVErlh5kCDqw3x0an5Ur3mT9j9CwJsDwmhmz4i1IgYM1a0SPqqEhClvjX+s5pU4nHjmVaGXWK96pwsiGcQ==
+  dependencies:
+    "@babel/runtime" "^7.18.9"
+    "@types/d3" "^7.4.0"
+    "@types/resize-observer-browser" "^0.1.7"
+    classcat "^5.0.3"
+    d3-drag "^3.0.0"
+    d3-selection "^3.0.0"
+    d3-zoom "^3.0.0"
+    zustand "^3.7.2"
+
 react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.9.0:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
@@ -9951,3 +10277,8 @@ yn@3.1.1:
   version "3.1.1"
   resolved "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
+
+zustand@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-3.7.2.tgz#7b44c4f4a5bfd7a8296a3957b13e1c346f42514d"
+  integrity sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==


### PR DESCRIPTION
## ER Diagram Visualization for Database Schemas

This PR adds an interactive Entity-Relationship diagram feature to SQLTools. Right-click any schema node in the connection explorer and select "Show ER Diagram" to visualize tables, columns, and foreign key relationships.

### Features

- **Interactive diagram** built with React Flow — pan, zoom, and drag tables to rearrange
- **Column-level FK connections** — relationship lines connect from the specific FK column to the referenced PK column
- **Dagre auto-layout** — tables are positioned using a directed graph layout algorithm that minimizes edge crossings
- **Per-table color coding** — each table gets a consistent color; its outgoing FK edges use the same color for easy tracing
- **Focus mode** — click a table (or use the search field in the toolbar) to highlight it and its connected tables, dimming everything else. Press Escape or click the background to clear
- **Searchable table picker** — type to filter tables in the toolbar, select to focus and pan to the table
- **VS Code theme integration** — uses CSS variables so it adapts to any light or dark theme
- **Multi-driver support** — foreign key queries implemented for PostgreSQL, MySQL, MSSQL, and SQLite

### Bug fix

- Fixed a pre-existing event listener leak in the PG driver where `notice` handlers accumulated on pooled clients across queries

### Changes across packages

- **types** — Added `NSDatabase.IForeignKey` interface, `fetchForeignKeys` query builder, `getERDiagramData` driver method
- **base-driver** — Implemented `getERDiagramData` in `AbstractDriver`
- **driver.pg/mysql/mssql/sqlite** — Added `fetchForeignKeys` SQL queries
- **driver.pg** — Fixed notice listener leak in query method
- **language-server** — Added `GetERDiagramDataRequest` handler, `Connection.getERDiagramData` delegation
- **plugins/connection-manager** — New command, LSP contract, webview provider, and React Flow UI
- **extension** — Registered command, context menu on schema nodes, webpack entry point for ERDiagram webview

### How to test

1. Connect to a PostgreSQL (or MySQL/MSSQL/SQLite) database
2. Expand the connection → database → schemas in the sidebar
3. Right-click a schema → "Show ER Diagram"
4. Verify tables render with columns, PK/FK badges, and colored relationship lines
5. Click a table to enter focus mode; use the search field to find tables
6. Drag tables, pan, and zoom to verify interactivity

# Notes
I meant to write something that would solve #1304 but it is still lacking editing. Totally fine if a solution based on erd-editor is preferred.

---

Thank you for your contribution! Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
- [ ] You have made the needed changes to the docs
- [x] You have written a description of what is the purpose of this pull request above
