### PR TITLE
createSshTunnel: support `passphrase` for private key (types)

### DIFF
--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -10,6 +10,10 @@ This package is part of [vscode-sqltools](https://vscode-sqltools.mteixeira.dev?
 
 # Changelog
 
+### v0.2.1
+
+- Add `passphrase` on createSshTunnel() to align with SSH tunneling enhancement implemented in AbstractDriver in @sqltools/base-driver@0.2.4
+
 ### v0.2.0
 
 - Add IConnectionDriver.createSshTunnel() to align with SSH tunneling support implemented in AbstractDriver in @sqltools/base-driver@0.2.0

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -341,6 +341,7 @@ export interface IConnectionDriver {
       username: string;
       password?: string;
       privateKeyPath?: string;
+      passphrase?: string;
     },
     db: {
       host: string;

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -261,6 +261,14 @@ export interface IConnection<DriverOptions = any> {
      * @memberof IConnection.sshOptions
      */
     privateKeyPath?: string;
+
+    /**
+     * Passphrase for the private key
+     * @type {string}
+     * @default null
+     * @memberof IConnection.sshOptions
+     */
+    passphrase?: string;
   };
 
   // WONT BE INCLUDED IN SETTINGS

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sqltools/types",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "SQLTools interfaces and types",
   "types": "index.d.ts",
   "main": "index.js",


### PR DESCRIPTION
Adds type support for private key passphrase.

Merge this first, then publish the new npm @sqltools/types@0.2.1 package.