### PR TITLE
createSshTunnel: support passphrase for private key (base)

### DIFF
--- a/packages/base-driver/README.md
+++ b/packages/base-driver/README.md
@@ -12,6 +12,11 @@ Inactive icon: Opacity 50%, no margins and paddings
 
 ## Changelog
 
+### v0.2.4
+
+- Use @sqltools/types@0.2.1.
+- Support `passphrase` for private key.
+
 ### v0.2.3
 
 - Support SSH tunnel that uses password.

--- a/packages/base-driver/package.json
+++ b/packages/base-driver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sqltools/base-driver",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "SQLTools Base Driver",
   "publishConfig": {
     "access": "public",
@@ -39,7 +39,7 @@
     "typescript": "~4.8.3"
   },
   "dependencies": {
-    "@sqltools/types": "^0.2.0",
+    "@sqltools/types": "^0.2.1",
     "@sqltools/log": "latest",
     "vscode-uri": "^3.0.3",
     "env-paths": "^2.2.0",

--- a/packages/base-driver/src/index.ts
+++ b/packages/base-driver/src/index.ts
@@ -143,6 +143,7 @@ export default abstract class AbstractDriver<ConnectionType extends any, DriverO
       username: string;
       password?: string;
       privateKeyPath?: string;
+      passphrase?: string;
     },
     db: {
       host: string;
@@ -163,6 +164,7 @@ export default abstract class AbstractDriver<ConnectionType extends any, DriverO
         username: ssh.username,
         ...(ssh.password ? { password: ssh.password } : {}),
         ...(ssh.privateKeyPath ? { privateKey: fs.readFileSync(ssh.privateKeyPath) } : {}),
+        ...(ssh.passphrase ? { passphrase: ssh.passphrase } : {}),
       },
       {
         dstAddr: db.host,


### PR DESCRIPTION
Accept optional `passphrase` from driver for ssh tunnel's private key.

Merge this second, then publish the new npm @sqltools/base-driver@0.2.4 package.