### PR TITLE
Fix bugs in _openResultsWebview method

### DIFF
--- a/packages/plugins/connection-manager/extension.ts
+++ b/packages/plugins/connection-manager/extension.ts
@@ -536,12 +536,13 @@ export class ConnectionManagerPlugin implements IExtensionPlugin {
 
 
   private async _openResultsWebview(connId: string, reUseId: string) {
-    const requestId = reUseId || Config.results.reuseTabs === 'connection' ? connId : generateId();
+    const requestId = reUseId || (Config.results.reuseTabs === 'connection' ? connId : generateId());
     const view = this.resultsWebview.get(requestId);
     view.onDidDispose(() => {
       this.client.sendRequest(ReleaseResultsRequest, { connId, requestId });
     });
     await view.show();
+    view.sendMessage('SET_STATE', { loading: true });
     return view;
   }
   private _connect = async (force = false): Promise<IConnection> => {


### PR DESCRIPTION
Fix operator precedence bug in `_openResultsWebview` and missing loading state on reused result panels

## Problem

In `ConnectionManagerPlugin._openResultsWebview`, the `requestId` computation:

```ts
const requestId = reUseId || Config.results.reuseTabs === 'connection' ? connId : generateId();
```

is parsed by JS operator precedence as:

```ts
const requestId = (reUseId || Config.results.reuseTabs === 'connection') ? connId : generateId();
```

instead of the intended:

```ts
const requestId = reUseId || (Config.results.reuseTabs === 'connection' ? connId : generateId());
```

As a result, whenever `reuseTabs` is set to `'connection'`, any explicitly passed `reUseId` (e.g. when paginating an existing result tab) was silently discarded and replaced with `connId`. This caused a brand-new results tab to be opened instead of reusing the existing one, leaving the original tab stuck on its last state/spinner.

Additionally, when a webview panel *is* reused (`panel.reveal()` rather than a fresh `createWebviewPanel()`), no message was ever sent to tell the already-mounted React app to show a loading state. Freshly created panels happened to work correctly because their initial React state defaults to `loading: true`, masking this issue for the first query on a new tab.

## Fix

- Wrap the ternary in parentheses so `reUseId` takes precedence as intended, and the reuse-by-connection logic only applies as a fallback when no `reUseId` is provided.
- Explicitly send a `SET_STATE` message with `loading: true` right after `view.show()`, so reused panels correctly show a loading indicator for every subsequent query, not just the first one.

## Impact

- Result tabs are now correctly reused according to `sqltools.results.reuseTabs` settings instead of spawning duplicate tabs.
- Reused result panels now show a loading spinner while a query is running, matching the behavior of freshly opened panels.

## Files changed

- `packages/plugins/connection-manager/extension.ts`
